### PR TITLE
Implement physically normalized atmospheric phase screens

### DIFF
--- a/fiatlux/optics/atmosphere.py
+++ b/fiatlux/optics/atmosphere.py
@@ -1,54 +1,225 @@
+"""Statistical models for atmospheric optical-path-difference screens.
+
+Frequency coordinates are in cycles per metre. The phase power spectral
+density follows the usual two-dimensional von Karman convention
+
+    W_phi(f) = 0.023 r0**(-5/3) (f**2 + 1/L0**2)**(-11/6),
+
+and has units radian**2 metre**2. ``r0`` is defined at
+``reference_wavelength``. A Kolmogorov spectrum is obtained with
+``outer_scale=None``.
+
+Screens are synthesized directly from this PSD using the frequency-bin area;
+there is no empirical RMS renormalization or spatial-frequency filter. The
+only exceptional Fourier coefficient is piston: it is removed by default
+because it is unobservable in a single pupil, and because the pure Kolmogorov
+spectrum diverges at zero frequency.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import math
+
 import torch
 
 from fiatlux.core.grid import Grid
-from fiatlux.core.field import Field
-
-import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
 
 
-class AtmosphereModel:
-    def __init__(self, grid: Grid):
+class AtmosphereModel(ABC):
+    """Base class for phase-screen statistics on a fixed spatial grid."""
+
+    def __init__(
+        self,
+        grid: Grid,
+        *,
+        reference_wavelength: float,
+        seed: int | None = None,
+        dtype: torch.dtype = torch.float64,
+    ) -> None:
+        if grid.nx < 2 or grid.ny < 2:
+            raise ValueError("Atmospheric grids require nx >= 2 and ny >= 2.")
+        if grid.dx <= 0 or grid.dy <= 0:
+            raise ValueError("Atmospheric grid spacings dx and dy must be positive.")
+        if reference_wavelength <= 0:
+            raise ValueError("reference_wavelength must be positive.")
+        if dtype not in (torch.float32, torch.float64):
+            raise TypeError("dtype must be torch.float32 or torch.float64.")
+
         self.grid = grid
-        self.psd: torch.Tensor | None = None
+        self.reference_wavelength = float(reference_wavelength)
+        self.dtype = dtype
+        self.generator = torch.Generator(device=grid.device)
+        if seed is None:
+            self.generator.seed()
+        else:
+            self.generator.manual_seed(seed)
 
-        self.compute_psd()
+        # PSD arrays use native, unshifted torch.fft ordering.
+        self.phase_psd = self.compute_phase_psd()
 
-    def compute_psd(self) -> None:
-        raise NotImplementedError("compute_psd must be implemented in subclasses.")
+    @property
+    def psd(self) -> torch.Tensor:
+        """Phase PSD in radian^2 metre^2, in native FFT ordering."""
+        return self.phase_psd
+
+    @property
+    def frequency_bin_area(self) -> float:
+        """Area df_x df_y of one discrete Fourier-frequency bin."""
+        dfx = 1.0 / (self.grid.nx * self.grid.dx)
+        dfy = 1.0 / (self.grid.ny * self.grid.dy)
+        return dfx * dfy
+
+    def frequency_grid(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return ``(fx, fy)`` arrays shaped ``(ny, nx)`` in cycles/m."""
+        fx = torch.fft.fftfreq(
+            self.grid.nx,
+            d=self.grid.dx,
+            device=self.grid.device,
+            dtype=self.dtype,
+        )
+        fy = torch.fft.fftfreq(
+            self.grid.ny,
+            d=self.grid.dy,
+            device=self.grid.device,
+            dtype=self.dtype,
+        )
+        fy, fx = torch.meshgrid(fy, fx, indexing="ij")
+        return fx, fy
+
+    @abstractmethod
+    def compute_phase_psd(self) -> torch.Tensor:
+        """Return the two-dimensional phase PSD in radian^2 metre^2."""
+
+    def sample_phase(
+        self,
+        *,
+        generator: torch.Generator | None = None,
+        remove_piston: bool = True,
+    ) -> torch.Tensor:
+        """Draw a real phase screen in radians at the reference wavelength.
+
+        Filtering unit-variance real white noise automatically provides the
+        Hermitian Fourier coefficients required for a real-valued screen. With
+        PyTorch's FFT normalization, the transfer function is
+        ``sqrt(N * W_phi * df_x * df_y)``, where ``N = nx * ny``.
+        """
+        rng = self.generator if generator is None else generator
+        white = torch.randn(
+            (self.grid.ny, self.grid.nx),
+            dtype=self.dtype,
+            device=self.grid.device,
+            generator=rng,
+        )
+
+        transfer = torch.sqrt(
+            self.phase_psd
+            * self.frequency_bin_area
+            * (self.grid.nx * self.grid.ny)
+        )
+        if remove_piston:
+            transfer = transfer.clone()
+            transfer[0, 0] = 0.0
+
+        return torch.fft.ifft2(torch.fft.fft2(white) * transfer).real
+
+    def sample_opd(
+        self,
+        *,
+        generator: torch.Generator | None = None,
+        remove_piston: bool = True,
+    ) -> torch.Tensor:
+        """Draw an optical-path-difference screen in metres."""
+        phase = self.sample_phase(
+            generator=generator,
+            remove_piston=remove_piston,
+        )
+        return phase * (self.reference_wavelength / (2.0 * math.pi))
 
 
 class KolmogorovAtmosphereModel(AtmosphereModel):
+    """Kolmogorov or von Karman phase-screen model.
+
+    Parameters
+    ----------
+    grid
+        Spatial sampling grid in metres.
+    r0
+        Fried parameter in metres at ``reference_wavelength``.
+    reference_wavelength
+        Wavelength in metres at which ``r0`` and phase are defined.
+    outer_scale
+        Von Karman outer scale ``L0`` in metres. ``None`` selects the pure
+        Kolmogorov spectrum. No ad-hoc high-pass correction is applied.
+    seed
+        Optional seed for this model's private random-number generator.
+    dtype
+        Real floating-point dtype used for the PSD and generated screens.
+    """
+
+    def __init__(
+        self,
+        grid: Grid,
+        r0: float,
+        reference_wavelength: float = 500e-9,
+        *,
+        outer_scale: float | None = None,
+        seed: int | None = None,
+        dtype: torch.dtype = torch.float64,
+    ) -> None:
+        if r0 <= 0:
+            raise ValueError("r0 must be positive.")
+        if outer_scale is not None and outer_scale <= 0:
+            raise ValueError("outer_scale must be positive or None.")
+
+        self.r0 = float(r0)
+        self.outer_scale = None if outer_scale is None else float(outer_scale)
+        super().__init__(
+            grid,
+            reference_wavelength=reference_wavelength,
+            seed=seed,
+            dtype=dtype,
+        )
+
+    def compute_phase_psd(self) -> torch.Tensor:
+        fx, fy = self.frequency_grid()
+        frequency_squared = fx.square() + fy.square()
+
+        if self.outer_scale is None:
+            radial_term = frequency_squared.pow(-11.0 / 6.0)
+            # Pure Kolmogorov piston is divergent and physically unobservable.
+            radial_term[0, 0] = 0.0
+        else:
+            radial_term = (frequency_squared + 1.0 / self.outer_scale**2).pow(
+                -11.0 / 6.0
+            )
+
+        return 0.023 * self.r0 ** (-5.0 / 3.0) * radial_term
+
+
+class NCPAModel:
+    """Legacy power-law NCPA model, kept separate from atmospheric physics.
+
+    NCPA statistics are instrument-specific. This class intentionally retains
+    the existing normalized ``f**-3`` model for backward compatibility; it is
+    not used by :class:`KolmogorovAtmosphereModel`.
+    """
+
+    def __init__(self, grid: Grid) -> None:
+        self.grid = grid
+        self.compute_psd()
+
     def compute_psd(self) -> None:
-        fx = torch.fft.fftfreq(self.grid.nx, d=self.grid.dx)
-        fy = torch.fft.fftfreq(self.grid.ny, d=self.grid.dy)
-        fx, fy = torch.meshgrid(fx, fy, indexing="ij")
-        f = (fx**2 + fy**2) ** 0.5
+        fx = torch.fft.fftfreq(
+            self.grid.nx, d=self.grid.dx, device=self.grid.device
+        )
+        fy = torch.fft.fftfreq(
+            self.grid.ny, d=self.grid.dy, device=self.grid.device
+        )
+        fy, fx = torch.meshgrid(fy, fx, indexing="ij")
+        frequency = torch.sqrt(fx.square() + fy.square())
 
-        d = 20
-        fc = 1 / (2 * d)
-        hp = (f > fc).float()
-
-        r0 = 50e-2
-        self.psd = 0.023 * r0 ** (-5 / 3) * f ** (-11 / 3)
-        self.psd *= hp
-        self.psd[0, 0] = 0
-        self.psd = torch.fft.fftshift(self.psd)
-        self.psd *= 500e-9 / (2 * torch.pi)
-
-        plt.imshow(self.psd)
-
-
-class NCPAModel(AtmosphereModel):
-    def compute_psd(self) -> None:
-        fx = torch.fft.fftfreq(self.grid.nx, d=self.grid.dx)
-        fy = torch.fft.fftfreq(self.grid.ny, d=self.grid.dy)
-        fx, fy = torch.meshgrid(fx, fy, indexing="ij")
-        f = (fx**2 + fy**2) ** 0.5
-
-        self.psd = f ** (-3)
-        self.psd[0, 0] = 0
-        self.psd = torch.fft.fftshift(self.psd)
-        self.psd *= (5e-1) ** 2 / (self.psd.sum())
-
-        plt.imshow(self.psd, norm=LogNorm())
+        psd = frequency.pow(-3.0)
+        psd[0, 0] = 0.0
+        self.psd = torch.fft.fftshift(psd)
+        self.psd *= 0.5**2 / self.psd.sum()

--- a/fiatlux/optics/elements/mask.py
+++ b/fiatlux/optics/elements/mask.py
@@ -17,7 +17,6 @@ import os
 from itertools import cycle
 
 from astropy.io import fits
-import torchvision.transforms as transforms
 
 
 @dataclass
@@ -249,23 +248,22 @@ class Atmosphere(Mask):
         grid: Grid,
         atmosphere_model: AtmosphereModel,
         recompute: bool = True,
+        remove_piston: bool = True,
     ):
         self.atmosphere_model = atmosphere_model
+        self.remove_piston = remove_piston
         super().__init__(grid=grid, recompute=recompute)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(
+            (self.grid.ny, self.grid.nx),
+            device=self.grid.device,
+            dtype=self.atmosphere_model.dtype,
+        )
 
     def _build_opd(self) -> None:
-        cn = (
-            torch.randn(*self.atmosphere_model.psd.shape)
-            + 1j * torch.randn(*self.atmosphere_model.psd.shape)
-        ) * torch.sqrt(self.atmosphere_model.psd)
-
-        self.opd = torch.real(
-            torch.fft.ifftshift(torch.fft.ifft2(torch.fft.fftshift(cn)))
-            * 1
-            / (self.grid.nx * self.grid.dx)
+        self.opd = self.atmosphere_model.sample_opd(
+            remove_piston=self.remove_piston
         )
 
 

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -1,0 +1,104 @@
+import math
+
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.optics.atmosphere import KolmogorovAtmosphereModel
+
+
+def make_grid(nx=64, ny=48, dx=0.1, dy=0.12):
+    return Grid(nx=nx, ny=ny, dx=dx, dy=dy)
+
+
+def test_kolmogorov_psd_matches_analytical_law():
+    model = KolmogorovAtmosphereModel(
+        make_grid(), r0=0.2, reference_wavelength=500e-9, seed=1
+    )
+    fx, fy = model.frequency_grid()
+    f2 = fx.square() + fy.square()
+    expected = 0.023 * model.r0 ** (-5.0 / 3.0) * f2[1, 2] ** (-11.0 / 6.0)
+
+    assert model.phase_psd.shape == (model.grid.ny, model.grid.nx)
+    torch.testing.assert_close(model.phase_psd[1, 2], expected)
+    assert model.phase_psd[0, 0] == 0
+
+
+def test_von_karman_psd_has_finite_low_frequency_power():
+    model = KolmogorovAtmosphereModel(
+        make_grid(),
+        r0=0.2,
+        reference_wavelength=500e-9,
+        outer_scale=25.0,
+    )
+    expected_dc = 0.023 * model.r0 ** (-5.0 / 3.0) * (1 / 25.0**2) ** (
+        -11.0 / 6.0
+    )
+    torch.testing.assert_close(
+        model.phase_psd[0, 0],
+        torch.as_tensor(expected_dc, dtype=model.dtype),
+    )
+
+
+def test_screen_is_real_rectangular_and_reproducible():
+    grid = make_grid()
+    kwargs = dict(
+        grid=grid,
+        r0=0.2,
+        reference_wavelength=500e-9,
+        outer_scale=25.0,
+        seed=42,
+    )
+    model_a = KolmogorovAtmosphereModel(**kwargs)
+    model_b = KolmogorovAtmosphereModel(**kwargs)
+
+    phase_a = model_a.sample_phase()
+    phase_b = model_b.sample_phase()
+
+    assert phase_a.shape == (grid.ny, grid.nx)
+    assert not phase_a.is_complex()
+    assert torch.isfinite(phase_a).all()
+    assert phase_a.mean().abs() < 1e-12
+    torch.testing.assert_close(phase_a, phase_b)
+
+
+def test_opd_is_phase_converted_at_reference_wavelength():
+    kwargs = dict(
+        grid=make_grid(), r0=0.2, reference_wavelength=700e-9, seed=7
+    )
+    phase = KolmogorovAtmosphereModel(**kwargs).sample_phase()
+    opd = KolmogorovAtmosphereModel(**kwargs).sample_opd()
+    torch.testing.assert_close(opd, phase * 700e-9 / (2 * math.pi))
+
+
+def test_screen_variance_follows_integrated_psd_without_renormalization():
+    model = KolmogorovAtmosphereModel(
+        make_grid(nx=32, ny=24),
+        r0=0.2,
+        reference_wavelength=500e-9,
+        outer_scale=25.0,
+        seed=12,
+    )
+    psd_without_piston = model.phase_psd.clone()
+    psd_without_piston[0, 0] = 0.0
+    expected_variance = psd_without_piston.sum() * model.frequency_bin_area
+
+    measured_variance = torch.stack(
+        [model.sample_phase().square().mean() for _ in range(256)]
+    ).mean()
+
+    torch.testing.assert_close(measured_variance, expected_variance, rtol=0.08, atol=0)
+
+
+@pytest.mark.parametrize(
+    "bad_kwargs",
+    [
+        {"r0": 0.0},
+        {"r0": -0.1},
+        {"r0": 0.2, "outer_scale": 0.0},
+        {"r0": 0.2, "reference_wavelength": 0.0},
+    ],
+)
+def test_invalid_physical_parameters_are_rejected(bad_kwargs):
+    with pytest.raises(ValueError):
+        KolmogorovAtmosphereModel(make_grid(), **bad_kwargs)


### PR DESCRIPTION
## Résumé

- implémente une PSD de phase Kolmogorov/von Kármán avec `r0`, longueur d’onde de référence et échelle externe explicites ;
- synthétise des écrans réels avec la normalisation FFT déduite de `W_phi × df_x × df_y`, sans RMS cible, high-pass empirique ni autre tweak de PSD ;
- convertit proprement phase → OPD et rend le retrait du piston explicite ;
- utilise un générateur aléatoire local reproductible et respecte grille, device et dtype ;
- conserve le modèle NCPA historique séparément et supprime les effets de bord de plotting/import inutiles.

## Validation

- `python -m pytest -q` : 9 tests passés
- vérification analytique de la PSD Kolmogorov et du DC von Kármán
- écrans réels, rectangulaires et reproductibles
- vérification statistique : variance des écrans conforme à l’intégrale discrète de la PSD, sans renormalisation
- conversion phase/OPD et paramètres invalides testés

## Note physique

Le piston est retiré par défaut : il est inobservable sur une pupille unique et la PSD Kolmogorov pure diverge à fréquence nulle. Ce traitement est explicite et désactivable ; aucun autre coefficient spectral n’est modifié.

Traite la partie atmosphère de #30. Lié à #31 et #35.