### PR TITLE
Fix atmosphere dtype compatibility with propagation

### DIFF
--- a/fiatlux/optics/atmosphere.py
+++ b/fiatlux/optics/atmosphere.py
@@ -35,7 +35,7 @@ class AtmosphereModel(ABC):
         *,
         reference_wavelength: float,
         seed: int | None = None,
-        dtype: torch.dtype = torch.float64,
+        dtype: torch.dtype = torch.float32,
     ) -> None:
         if grid.nx < 2 or grid.ny < 2:
             raise ValueError("Atmospheric grids require nx >= 2 and ny >= 2.")
@@ -165,7 +165,7 @@ class KolmogorovAtmosphereModel(AtmosphereModel):
         *,
         outer_scale: float | None = None,
         seed: int | None = None,
-        dtype: torch.dtype = torch.float64,
+        dtype: torch.dtype = torch.float32,
     ) -> None:
         if r0 <= 0:
             raise ValueError("r0 must be positive.")

--- a/tests/test_atmosphere.py
+++ b/tests/test_atmosphere.py
@@ -58,9 +58,17 @@ def test_screen_is_real_rectangular_and_reproducible():
     assert phase_a.shape == (grid.ny, grid.nx)
     assert not phase_a.is_complex()
     assert torch.isfinite(phase_a).all()
-    assert phase_a.mean().abs() < 1e-12
+    assert phase_a.mean().abs() < 1e-5
     torch.testing.assert_close(phase_a, phase_b)
 
+
+
+def test_default_dtype_matches_fiatlux_complex64_pipeline():
+    model = KolmogorovAtmosphereModel(make_grid(), r0=0.2, seed=3)
+
+    assert model.phase_psd.dtype == torch.float32
+    assert model.sample_phase().dtype == torch.float32
+    assert model.sample_opd().dtype == torch.float32
 
 def test_opd_is_phase_converted_at_reference_wavelength():
     kwargs = dict(


### PR DESCRIPTION
## Problème

L’atmosphère introduite par #36 utilisait `float64` par défaut. Son OPD faisait donc promouvoir un champ Fiatlux `complex64` en `complex128`, puis la propagation échouait lorsque ce champ rencontrait une matrice `complex64` :

```
expected m1 and m2 to have the same dtype,
but got complex<float> != complex<double>
```

## Correctif

- utilise `torch.float32` par défaut pour la PSD, la phase et l’OPD atmosphériques, conformément au pipeline Fiatlux actuel ;
- conserve `dtype=torch.float64` comme option explicite ;
- ajoute un test garantissant que le dtype par défaut reste compatible avec un pipeline `complex64` ;
- adapte la tolérance du test de piston à la précision `float32`.

La physique et la normalisation de la PSD ne sont pas modifiées.