### PR TITLE
Define and validate the NCPA statistical model

### DIFF
--- a/fiatlux/optics/atmosphere.py
+++ b/fiatlux/optics/atmosphere.py
@@ -1,4 +1,4 @@
-"""Statistical models for atmospheric optical-path-difference screens.
+"""Statistical models for atmospheric and instrumental OPD screens.
 
 Frequency coordinates are in cycles per metre. The phase power spectral
 density follows the usual two-dimensional von Karman convention
@@ -198,28 +198,136 @@ class KolmogorovAtmosphereModel(AtmosphereModel):
 
 
 class NCPAModel:
-    """Legacy power-law NCPA model, kept separate from atmospheric physics.
+    """Stationary isotropic power-law model for instrumental NCPA.
 
-    NCPA statistics are instrument-specific. This class intentionally retains
-    the existing normalized ``f**-3`` model for backward compatibility; it is
-    not used by :class:`KolmogorovAtmosphereModel`.
+    Unlike atmospheric phase statistics, NCPA are defined directly as an
+    optical-path-difference field. Frequencies are in cycles per metre and
+    ``opd_psd`` has units metre**4 (OPD**2 per inverse-square-metre frequency
+    area). Its integral over the sampled two-dimensional frequency plane is
+    ``opd_rms**2``.
+
+    The requested RMS normalizes the *ensemble PSD*, not each random draw.
+    Individual realizations therefore have naturally fluctuating RMS; no
+    post-generation rescaling or hidden PSD shaping is performed.
+
+    Parameters
+    ----------
+    grid
+        Spatial sampling grid in metres.
+    opd_rms
+        Ensemble RMS optical path difference in metres, excluding piston.
+    spectral_index
+        Positive exponent ``alpha`` of the radial power law ``f**(-alpha)``.
+    outer_scale
+        Optional low-frequency roll-off scale in metres. If supplied, the
+        shape is ``(f**2 + 1/L0**2)**(-alpha/2)``. Piston remains excluded.
+    seed
+        Optional seed for this model's private random-number generator.
+    dtype
+        Real floating-point dtype used for the PSD and generated screens.
     """
 
-    def __init__(self, grid: Grid) -> None:
-        self.grid = grid
-        self.compute_psd()
+    def __init__(
+        self,
+        grid: Grid,
+        opd_rms: float,
+        *,
+        spectral_index: float = 3.0,
+        outer_scale: float | None = None,
+        seed: int | None = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        if grid.nx < 2 or grid.ny < 2:
+            raise ValueError("NCPA grids require nx >= 2 and ny >= 2.")
+        if grid.dx <= 0 or grid.dy <= 0:
+            raise ValueError("NCPA grid spacings dx and dy must be positive.")
+        if opd_rms <= 0:
+            raise ValueError("opd_rms must be positive.")
+        if spectral_index <= 0:
+            raise ValueError("spectral_index must be positive.")
+        if outer_scale is not None and outer_scale <= 0:
+            raise ValueError("outer_scale must be positive or None.")
+        if dtype not in (torch.float32, torch.float64):
+            raise TypeError("dtype must be torch.float32 or torch.float64.")
 
-    def compute_psd(self) -> None:
+        self.grid = grid
+        self.opd_rms = float(opd_rms)
+        self.spectral_index = float(spectral_index)
+        self.outer_scale = None if outer_scale is None else float(outer_scale)
+        self.dtype = dtype
+        self.generator = torch.Generator(device=grid.device)
+        if seed is None:
+            self.generator.seed()
+        else:
+            self.generator.manual_seed(seed)
+
+        self.opd_psd = self.compute_opd_psd()
+
+    @property
+    def psd(self) -> torch.Tensor:
+        """OPD PSD in metre**4, in native unshifted FFT ordering."""
+        return self.opd_psd
+
+    @property
+    def frequency_bin_area(self) -> float:
+        """Area ``df_x df_y`` of one Fourier-frequency bin in metre**-2."""
+        return 1.0 / (
+            self.grid.nx
+            * self.grid.dx
+            * self.grid.ny
+            * self.grid.dy
+        )
+
+    def frequency_grid(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return ``(fx, fy)`` arrays shaped ``(ny, nx)`` in cycles/m."""
         fx = torch.fft.fftfreq(
-            self.grid.nx, d=self.grid.dx, device=self.grid.device
+            self.grid.nx,
+            d=self.grid.dx,
+            device=self.grid.device,
+            dtype=self.dtype,
         )
         fy = torch.fft.fftfreq(
-            self.grid.ny, d=self.grid.dy, device=self.grid.device
+            self.grid.ny,
+            d=self.grid.dy,
+            device=self.grid.device,
+            dtype=self.dtype,
         )
         fy, fx = torch.meshgrid(fy, fx, indexing="ij")
-        frequency = torch.sqrt(fx.square() + fy.square())
+        return fx, fy
 
-        psd = frequency.pow(-3.0)
-        psd[0, 0] = 0.0
-        self.psd = torch.fft.fftshift(psd)
-        self.psd *= 0.5**2 / self.psd.sum()
+    def compute_opd_psd(self) -> torch.Tensor:
+        """Build an OPD PSD whose discrete integral is ``opd_rms**2``."""
+        fx, fy = self.frequency_grid()
+        frequency_squared = fx.square() + fy.square()
+        if self.outer_scale is None:
+            shape = frequency_squared.pow(-self.spectral_index / 2.0)
+        else:
+            shape = (
+                frequency_squared + 1.0 / self.outer_scale**2
+            ).pow(-self.spectral_index / 2.0)
+
+        shape[0, 0] = 0.0
+        normalization = self.opd_rms**2 / (
+            shape.sum() * self.frequency_bin_area
+        )
+        return shape * normalization
+
+    def sample_opd(
+        self,
+        *,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Draw a real, piston-free OPD screen in metres."""
+        rng = self.generator if generator is None else generator
+        white = torch.randn(
+            (self.grid.ny, self.grid.nx),
+            dtype=self.dtype,
+            device=self.grid.device,
+            generator=rng,
+        )
+        transfer = torch.sqrt(
+            self.opd_psd
+            * self.frequency_bin_area
+            * (self.grid.nx * self.grid.ny)
+        )
+        return torch.fft.ifft2(torch.fft.fft2(white) * transfer).real

--- a/fiatlux/optics/elements/mask.py
+++ b/fiatlux/optics/elements/mask.py
@@ -272,29 +272,20 @@ class NCPA(Mask):
         self,
         grid: Grid,
         ncpa_model: NCPAModel,
-        amplitude: float,
         recompute: bool = True,
     ):
         self.ncpa_model = ncpa_model
-        self.amplitude = amplitude
         super().__init__(grid=grid, recompute=recompute)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
-
-    def _build_opd(self) -> None:
-        cn = (
-            torch.randn(*self.ncpa_model.psd.shape)
-            + 1j * torch.randn(*self.ncpa_model.psd.shape)
-        ) * torch.sqrt(self.ncpa_model.psd)
-
-        self.opd = torch.real(
-            torch.fft.ifftshift(torch.fft.ifft2(torch.fft.fftshift(cn)))
-            * 1
-            / (self.grid.nx * self.grid.dx)
+        self.transmission = torch.ones(
+            (self.grid.ny, self.grid.nx),
+            device=self.grid.device,
+            dtype=self.ncpa_model.dtype,
         )
 
-        self.opd *= self.amplitude / self.opd.std()
+    def _build_opd(self) -> None:
+        self.opd = self.ncpa_model.sample_opd()
 
 
 class Random(Mask):

--- a/tests/test_ncpa.py
+++ b/tests/test_ncpa.py
@@ -1,0 +1,105 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.optics.atmosphere import NCPAModel
+
+
+def make_grid(nx=48, ny=32, dx=0.08, dy=0.11):
+    return Grid(nx=nx, ny=ny, dx=dx, dy=dy)
+
+
+def test_opd_psd_has_requested_integrated_variance():
+    model = NCPAModel(make_grid(), opd_rms=80e-9, seed=1)
+
+    integrated_variance = model.opd_psd.sum() * model.frequency_bin_area
+
+    assert model.opd_psd.shape == (model.grid.ny, model.grid.nx)
+    assert model.opd_psd.dtype == torch.float32
+    assert model.opd_psd[0, 0] == 0
+    torch.testing.assert_close(
+        integrated_variance,
+        torch.as_tensor((80e-9) ** 2, dtype=model.dtype),
+        rtol=2e-6,
+        atol=0,
+    )
+
+
+def test_opd_psd_follows_requested_power_law():
+    model = NCPAModel(
+        make_grid(dx=0.1, dy=0.1),
+        opd_rms=100e-9,
+        spectral_index=2.5,
+    )
+    fx, fy = model.frequency_grid()
+    frequency = torch.sqrt(fx.square() + fy.square())
+    first = (1, 2)
+    second = (2, 3)
+    expected_ratio = (frequency[first] / frequency[second]).pow(-2.5)
+
+    torch.testing.assert_close(
+        model.opd_psd[first] / model.opd_psd[second], expected_ratio
+    )
+
+
+def test_opd_screen_is_real_rectangular_and_reproducible():
+    kwargs = dict(
+        grid=make_grid(),
+        opd_rms=120e-9,
+        spectral_index=3.0,
+        outer_scale=2.0,
+        seed=42,
+    )
+    opd_a = NCPAModel(**kwargs).sample_opd()
+    opd_b = NCPAModel(**kwargs).sample_opd()
+
+    assert opd_a.shape == (kwargs["grid"].ny, kwargs["grid"].nx)
+    assert not opd_a.is_complex()
+    assert torch.isfinite(opd_a).all()
+    assert opd_a.mean().abs() < 1e-12
+    torch.testing.assert_close(opd_a, opd_b)
+
+
+def test_ensemble_variance_follows_psd_without_per_screen_rescaling():
+    model = NCPAModel(
+        make_grid(nx=32, ny=24),
+        opd_rms=100e-9,
+        spectral_index=3.0,
+        seed=12,
+    )
+    variances = torch.stack(
+        [model.sample_opd().square().mean() for _ in range(256)]
+    )
+
+    torch.testing.assert_close(
+        variances.mean(),
+        torch.as_tensor(model.opd_rms**2, dtype=model.dtype),
+        rtol=0.08,
+        atol=0,
+    )
+    assert variances.std() > 0
+
+
+def test_external_generator_controls_sampling():
+    model = NCPAModel(make_grid(), opd_rms=100e-9, seed=1)
+    generator_a = torch.Generator().manual_seed(9)
+    generator_b = torch.Generator().manual_seed(9)
+
+    torch.testing.assert_close(
+        model.sample_opd(generator=generator_a),
+        model.sample_opd(generator=generator_b),
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_kwargs",
+    [
+        {"opd_rms": 0.0},
+        {"opd_rms": -1e-9},
+        {"opd_rms": 1e-9, "spectral_index": 0.0},
+        {"opd_rms": 1e-9, "outer_scale": 0.0},
+    ],
+)
+def test_invalid_ncpa_parameters_are_rejected(bad_kwargs):
+    with pytest.raises(ValueError):
+        NCPAModel(make_grid(), **bad_kwargs)


### PR DESCRIPTION
## Résumé

- définit la PSD NCPA comme une **PSD d’OPD** en `m⁴`, avec fréquences en cycles/m ;
- expose explicitement `opd_rms`, `spectral_index` et l’éventuelle `outer_scale` ;
- normalise l’intégrale discrète de la PSD à `opd_rms²` ;
- synthétise un écran OPD réel par filtrage d’un bruit blanc avec la normalisation FFT correcte ;
- retire uniquement le piston et n’applique aucun shaping spectral caché ;
- utilise un générateur local reproductible, avec contrôle du device et du dtype ;
- supprime la renormalisation réalisation-par-réalisation de l’élément `NCPA`.

## Sémantique statistique

`opd_rms` est le RMS **d’ensemble** défini par la PSD. Le RMS d’une réalisation individuelle fluctue naturellement autour de cette valeur. Aucun facteur `target_rms / screen.std()` n’est appliqué après génération.

## Changement d’API

Avant :

```python
model = NCPAModel(grid)
ncpa = NCPA(grid, model, amplitude=100e-9)
```

Après :

```python
model = NCPAModel(
    grid,
    opd_rms=100e-9,
    spectral_index=3.0,
    seed=42,
)
ncpa = NCPA(grid, model)
```

## Validation

- 19 tests atmosphère + NCPA passés ;
- intégrale de PSD égale à `opd_rms²` ;
- pente spectrale analytique vérifiée ;
- écrans réels, rectangulaires et reproductibles ;
- variance d’ensemble vérifiée sans renormalisation individuelle ;
- paramètres invalides testés.

Closes #38.