### PR TITLE
Fix Field transfer and arithmetic

### DIFF
--- a/fiatlux/core/field.py
+++ b/fiatlux/core/field.py
@@ -1,6 +1,7 @@
 # field.py
 from __future__ import annotations
 from dataclasses import dataclass
+from numbers import Number
 import torch
 
 from fiatlux.core.grid import BaseGrid
@@ -30,24 +31,74 @@ class Field:
     # def is_frequency(self) -> bool:
     #     return isinstance(self.grid, FrequencyGrid)
 
-    def to(self, device: torch.device) -> Field:
-        return Field(self.amplitude.to(device), self.grid.to(device), self.wavelength)
+    def to(self, device: torch.device | str) -> Field:
+        """Return a new field with all tensor state moved to ``device``.
 
-    def __rmul__(self, tensor: torch.Tensor) -> Field:
-        return Field(tensor * self.complex_amplitude, self.grid, self.spectrum)
-
-    def __sub__(self, tensor: torch.Tensor) -> Field:
-        return Field(self.complex_amplitude - tensor, self.grid, self.spectrum)
-
-    def __sub__(self, field: Field) -> Field:
+        The complex-amplitude, wavelength and flux dtypes are preserved.
+        Neither this field nor its associated grid and spectrum are mutated.
+        """
+        device = torch.device(device)
         return Field(
-            self.complex_amplitude - field.complex_amplitude, self.grid, self.spectrum
+            self.complex_amplitude.to(device),
+            self.grid.to(device),
+            self.spectrum.to(device),
         )
 
-    def __add__(self, field: Field) -> Field:
-        return Field(
-            self.complex_amplitude + field.complex_amplitude, self.grid, self.spectrum
-        )
+    def _validate_compatible_field(self, other: Field) -> None:
+        if self.grid != other.grid:
+            raise ValueError("Field grids must be identical for arithmetic.")
+        if self.complex_amplitude.shape != other.complex_amplitude.shape:
+            raise ValueError(
+                "Field amplitudes must have identical shapes for arithmetic."
+            )
+        for name in ("wavelengths", "fluxes"):
+            left = getattr(self.spectrum, name)
+            right = getattr(other.spectrum, name)
+            if (
+                left.shape != right.shape
+                or left.device != right.device
+                or left.dtype != right.dtype
+                or not torch.equal(left, right)
+            ):
+                raise ValueError(
+                    f"Field spectra must have identical {name} for arithmetic."
+                )
+
+    def _operand(self, other: Field | torch.Tensor | Number):
+        if isinstance(other, Field):
+            self._validate_compatible_field(other)
+            return other.complex_amplitude
+        if isinstance(other, (torch.Tensor, Number)):
+            return other
+        return NotImplemented
+
+    def __add__(self, other: Field | torch.Tensor | Number) -> Field:
+        operand = self._operand(other)
+        if operand is NotImplemented:
+            return NotImplemented
+        return Field(self.complex_amplitude + operand, self.grid, self.spectrum)
+
+    def __radd__(self, other: torch.Tensor | Number) -> Field:
+        return self + other
+
+    def __sub__(self, other: Field | torch.Tensor | Number) -> Field:
+        operand = self._operand(other)
+        if operand is NotImplemented:
+            return NotImplemented
+        return Field(self.complex_amplitude - operand, self.grid, self.spectrum)
+
+    def __rsub__(self, other: torch.Tensor | Number) -> Field:
+        if not isinstance(other, (torch.Tensor, Number)):
+            return NotImplemented
+        return Field(other - self.complex_amplitude, self.grid, self.spectrum)
+
+    def __mul__(self, other: torch.Tensor | Number) -> Field:
+        if not isinstance(other, (torch.Tensor, Number)):
+            return NotImplemented
+        return Field(self.complex_amplitude * other, self.grid, self.spectrum)
+
+    def __rmul__(self, other: torch.Tensor | Number) -> Field:
+        return self * other
 
     def plot(self, wavelength_index: int = -1):
         import matplotlib.pyplot as plt

--- a/fiatlux/core/spectrum.py
+++ b/fiatlux/core/spectrum.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from copy import copy
 from dataclasses import dataclass
 
 import torch
@@ -81,6 +82,13 @@ class Spectrum:
 
     def _set_fluxes(self, magnitude: float, band: Band, samples: int):
         self.fluxes = band.photon_flux(magnitude) * torch.ones(samples) / samples
+
+    def to(self, device: torch.device | str) -> Spectrum:
+        """Return a new spectrum object whose tensors are on ``device``."""
+        moved = copy(self)
+        moved.wavelengths = self.wavelengths.to(device)
+        moved.fluxes = self.fluxes.to(device)
+        return moved
 
     # @classmethod
     # def from_sampling(cls, band: torch.Tensor, Nu: torch.Tensor) -> Spectrum:

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,0 +1,118 @@
+import pytest
+import torch
+
+from fiatlux.core.field import Field
+from fiatlux.core.grid import Grid
+from fiatlux.core.spectrum import Band, Spectrum
+
+
+def make_field(
+    *,
+    amplitude: torch.Tensor | None = None,
+    grid: Grid | None = None,
+    spectrum: Spectrum | None = None,
+) -> Field:
+    grid = grid or Grid(nx=3, ny=2, dx=0.1, dy=0.2)
+    spectrum = spectrum or Spectrum(
+        magnitude=0,
+        band=Band(central_wavelength=1e-6, delta_wavelength=0.2e-6, f0=1),
+        samples=2,
+    )
+    amplitude = amplitude if amplitude is not None else torch.ones(
+        (2, 2, 3), dtype=torch.complex64
+    )
+    return Field(amplitude, grid, spectrum)
+
+
+def test_to_returns_new_consistent_field_without_mutating_source():
+    field = make_field()
+
+    moved = field.to("cpu")
+
+    assert moved is not field
+    assert moved.grid is not field.grid
+    assert moved.spectrum is not field.spectrum
+    assert moved.grid.device == torch.device("cpu")
+    assert moved.complex_amplitude.device == torch.device("cpu")
+    assert moved.spectrum.wavelengths.device == torch.device("cpu")
+    assert moved.spectrum.fluxes.device == torch.device("cpu")
+    assert moved.complex_amplitude.dtype == field.complex_amplitude.dtype
+    assert moved.spectrum.wavelengths.dtype == field.spectrum.wavelengths.dtype
+    assert moved.spectrum.fluxes.dtype == field.spectrum.fluxes.dtype
+    torch.testing.assert_close(moved.complex_amplitude, field.complex_amplitude)
+    torch.testing.assert_close(moved.spectrum.wavelengths, field.spectrum.wavelengths)
+    torch.testing.assert_close(moved.spectrum.fluxes, field.spectrum.fluxes)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_to_cuda_moves_every_tensor_and_preserves_dtype():
+    field = make_field()
+
+    moved = field.to("cuda")
+
+    assert moved.grid.device.type == "cuda"
+    assert moved.complex_amplitude.device.type == "cuda"
+    assert moved.spectrum.wavelengths.device.type == "cuda"
+    assert moved.spectrum.fluxes.device.type == "cuda"
+    assert moved.complex_amplitude.dtype == torch.complex64
+    assert moved.spectrum.wavelengths.dtype == field.spectrum.wavelengths.dtype
+    assert moved.spectrum.fluxes.dtype == field.spectrum.fluxes.dtype
+    assert field.grid.device.type == "cpu"
+    assert field.complex_amplitude.device.type == "cpu"
+
+
+def test_field_addition_and_subtraction():
+    left = make_field(amplitude=torch.full((2, 2, 3), 3, dtype=torch.complex64))
+    right = make_field(
+        amplitude=torch.full((2, 2, 3), 2, dtype=torch.complex64),
+        grid=left.grid,
+        spectrum=left.spectrum,
+    )
+
+    torch.testing.assert_close(
+        (left + right).complex_amplitude,
+        torch.full_like(left.complex_amplitude, 5),
+    )
+    torch.testing.assert_close(
+        (left - right).complex_amplitude,
+        torch.ones_like(left.complex_amplitude),
+    )
+
+
+def test_tensor_and_scalar_arithmetic():
+    field = make_field()
+    tensor = torch.full((2, 2, 3), 2, dtype=torch.complex64)
+
+    torch.testing.assert_close((field + tensor).complex_amplitude, tensor + 1)
+    torch.testing.assert_close((2 + field).complex_amplitude, tensor + 1)
+    torch.testing.assert_close((field - tensor).complex_amplitude, -torch.ones_like(tensor))
+    torch.testing.assert_close((2 - field).complex_amplitude, torch.ones_like(tensor))
+    torch.testing.assert_close((field * tensor).complex_amplitude, tensor)
+    torch.testing.assert_close((2 * field).complex_amplitude, tensor)
+
+
+@pytest.mark.parametrize("difference", ["grid", "shape", "wavelengths", "fluxes"])
+def test_field_arithmetic_rejects_incompatible_fields(difference):
+    left = make_field()
+    right = make_field(grid=left.grid, spectrum=left.spectrum)
+
+    if difference == "grid":
+        right.grid = Grid(nx=3, ny=2, dx=0.11, dy=0.2)
+    elif difference == "shape":
+        right.complex_amplitude = torch.ones((2, 2, 2), dtype=torch.complex64)
+    elif difference == "wavelengths":
+        right.spectrum = Spectrum(0, Band(1.1e-6, 0.2e-6, 1), 2)
+    else:
+        right.spectrum = Spectrum(1, Band(1e-6, 0.2e-6, 1), 2)
+
+    with pytest.raises(ValueError, match="must (be|have) identical"):
+        left - right
+
+
+def test_unsupported_arithmetic_returns_type_error():
+    field = make_field()
+
+    with pytest.raises(TypeError):
+        field + object()
+    with pytest.raises(TypeError):
+        field * field


### PR DESCRIPTION
## Résumé

- corrige `Field.to()` pour déplacer `complex_amplitude`, le `Grid` et les tenseurs du `Spectrum` sur le même device ;
- préserve les dtypes et ne mute pas le champ, la grille ou le spectre source ;
- supprime le double `__sub__` et définit un contrat arithmétique cohérent : addition/soustraction avec `Field`, tenseur ou scalaire, multiplication par tenseur ou scalaire ;
- valide explicitement grille, forme d’amplitude et spectre avant une opération entre deux champs ;
- ajoute les opérations inverses (`scalar + field`, `scalar - field`, `scalar * field`) et rejette les opérandes non supportés ;
- ajoute une couverture CPU complète et un test CUDA conditionnel.

## Validation

```text
50 passed, 1 skipped
```

Le test ignoré est le test de transfert CUDA lorsque CUDA n’est pas disponible sur la machine de test.

Closes #4.