### PR TITLE
Fix monochromatic Spectrum construction

### DIFF
--- a/fiatlux/core/spectrum.py
+++ b/fiatlux/core/spectrum.py
@@ -68,14 +68,17 @@ class PhotometricBand:
 
 class Spectrum:
     def __init__(self, magnitude: float, band: Band, samples: int):
-        self.magnitude = magnitude
-        self.wavelengths: torch.Tensor = None
-        self.fluxes: torch.Tensor = None
+        if not isinstance(samples, int) or isinstance(samples, bool) or samples < 1:
+            raise ValueError("samples must be a positive integer.")
 
+        self.magnitude = magnitude
         self._set_wavelengths(band, samples)
         self._set_fluxes(self.magnitude, band, samples)
 
     def _set_wavelengths(self, band: Band, samples: int):
+        if samples == 1:
+            self.wavelengths = torch.tensor([band.central_wavelength])
+            return
         self.wavelengths = band.central_wavelength + band.delta_wavelength * (
             torch.linspace(0, 1, samples) - 0.5
         )
@@ -90,40 +93,25 @@ class Spectrum:
         moved.fluxes = self.fluxes.to(device)
         return moved
 
-    # @classmethod
-    # def from_sampling(cls, band: torch.Tensor, Nu: torch.Tensor) -> Spectrum:
-    #     spectrum = cls.__new__(cls)
-    #     lambda_max = band.central_wavelength + band.delta_wavelength / 2
-    #     # lambda_min = band.central_wavelength - band.delta_wavelength / 2
-    #     d_lambda = lambda_max / Nu
-    #     n_lambda = int(torch.round(torch.asarray(band.delta_wavelength / d_lambda)))
-    #     spectrum.wavelengths = (
-    #         lambda_max - torch.linspace(n_lambda, 0, n_lambda) * d_lambda
-    #     )
-
-    #     cls._set_fluxes(band, n_lambda)
-    #     return spectrum
-
     @classmethod
     def from_sampling(cls, magnitude: float, band: Band, Nu: int) -> Spectrum:
-        """
-        Construit un spectre dont dλ correspond à 1 pixel dans le plan focal.
+        """Build a spectrum sampled at approximately one focal-plane pixel.
 
-        dλ = λ_max / n_pixels
+        At least one channel is always returned. Monochromatic bands and bands
+        narrower than the requested sampling are represented by one channel at
+        the central wavelength.
         """
+        if not isinstance(Nu, int) or isinstance(Nu, bool) or Nu < 1:
+            raise ValueError("Nu must be a positive integer.")
+
         lambda_max = band.central_wavelength + band.delta_wavelength / 2
         d_lambda = 2 * lambda_max / Nu
+        n_lambda = max(1, round(band.delta_wavelength / d_lambda))
 
-        # Nombre de canaux pour couvrir la bande avec ce pas
-        n_lambda = int(
-            torch.round(torch.as_tensor(float((band.delta_wavelength / d_lambda))))
-        )
-
-        spectrum = cls.__new__(cls)
-
-        spectrum.wavelengths = torch.sort(
-            lambda_max - torch.arange(n_lambda) * d_lambda
-        ).values
-        spectrum._set_fluxes(magnitude, band, n_lambda)
+        spectrum = cls(magnitude=magnitude, band=band, samples=n_lambda)
+        if n_lambda > 1:
+            spectrum.wavelengths = torch.sort(
+                lambda_max - torch.arange(n_lambda) * d_lambda
+            ).values
 
         return spectrum

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -1,0 +1,81 @@
+import pytest
+import torch
+
+from fiatlux.core.spectrum import Band, Spectrum
+
+
+MONOCHROMATIC_BAND = Band(
+    central_wavelength=1.2e-6,
+    delta_wavelength=0.0,
+    f0=1.1e12,
+)
+
+
+def test_monochromatic_spectrum_has_one_central_finite_channel():
+    spectrum = Spectrum(magnitude=5, band=MONOCHROMATIC_BAND, samples=1)
+
+    assert spectrum.wavelengths.shape == (1,)
+    assert spectrum.fluxes.shape == (1,)
+    torch.testing.assert_close(
+        spectrum.wavelengths,
+        torch.tensor([MONOCHROMATIC_BAND.central_wavelength]),
+    )
+    assert torch.isfinite(spectrum.fluxes).all()
+    assert spectrum.fluxes.item() == pytest.approx(
+        MONOCHROMATIC_BAND.photon_flux(5)
+    )
+
+
+@pytest.mark.parametrize(
+    "band",
+    [
+        MONOCHROMATIC_BAND,
+        Band(central_wavelength=1.2e-6, delta_wavelength=1e-12, f0=1.1e12),
+    ],
+)
+def test_from_sampling_guarantees_at_least_one_channel(band):
+    spectrum = Spectrum.from_sampling(magnitude=5, band=band, Nu=64)
+
+    assert spectrum.wavelengths.shape == (1,)
+    assert spectrum.fluxes.shape == (1,)
+    assert spectrum.wavelengths.item() == pytest.approx(band.central_wavelength)
+    assert torch.isfinite(spectrum.fluxes).all()
+
+
+def test_all_constructors_return_the_same_object_structure():
+    direct = Spectrum(magnitude=5, band=MONOCHROMATIC_BAND, samples=1)
+    sampled = Spectrum.from_sampling(magnitude=5, band=MONOCHROMATIC_BAND, Nu=64)
+
+    assert vars(direct).keys() == vars(sampled).keys()
+    assert sampled.magnitude == direct.magnitude
+    torch.testing.assert_close(sampled.wavelengths, direct.wavelengths)
+    torch.testing.assert_close(sampled.fluxes, direct.fluxes)
+
+
+def test_from_sampling_preserves_requested_multichannel_spacing_and_total_flux():
+    band = Band(central_wavelength=1.1e-6, delta_wavelength=0.2e-6, f0=1e12)
+    spectrum = Spectrum.from_sampling(magnitude=3, band=band, Nu=128)
+    expected_spacing = 2 * (
+        band.central_wavelength + band.delta_wavelength / 2
+    ) / 128
+
+    assert len(spectrum.wavelengths) > 1
+    torch.testing.assert_close(
+        torch.diff(spectrum.wavelengths),
+        torch.full_like(torch.diff(spectrum.wavelengths), expected_spacing),
+    )
+    assert spectrum.fluxes.sum().item() == pytest.approx(
+        band.photon_flux(3), rel=1e-6
+    )
+
+
+@pytest.mark.parametrize("samples", [0, -1, 1.5, True])
+def test_direct_constructor_rejects_invalid_sample_counts(samples):
+    with pytest.raises(ValueError, match="samples must be a positive integer"):
+        Spectrum(magnitude=0, band=MONOCHROMATIC_BAND, samples=samples)
+
+
+@pytest.mark.parametrize("Nu", [0, -1, 1.5, True])
+def test_from_sampling_rejects_invalid_grid_sizes(Nu):
+    with pytest.raises(ValueError, match="Nu must be a positive integer"):
+        Spectrum.from_sampling(magnitude=0, band=MONOCHROMATIC_BAND, Nu=Nu)


### PR DESCRIPTION
## Résumé

- garantit `samples >= 1` dans le constructeur principal ;
- représente un spectre à un canal exactement à la longueur d’onde centrale ;
- garantit au moins un canal dans `Spectrum.from_sampling()`, y compris pour une bande de largeur nulle ou très étroite ;
- remplace la construction partielle via `__new__` par le constructeur normal, de sorte que `magnitude`, `wavelengths` et `fluxes` soient toujours initialisés ;
- conserve l’espacement spectral existant pour les cas multicanaux ;
- valide explicitement `samples` et `Nu` ;
- ajoute des tests sur les cas monochromatiques, étroits, multicanaux et les paramètres invalides.

## Validation

```text
63 passed, 1 skipped
```

Le test ignoré est le test CUDA conditionnel déjà présent lorsque CUDA n’est pas disponible.

Closes #7.