### PR TITLE
Standardize ControlBasis n_modes as a property

### DIFF
--- a/fiatlux/optics/elements/deformable_mirror.py
+++ b/fiatlux/optics/elements/deformable_mirror.py
@@ -72,7 +72,8 @@ class GaussianZonalBasis(ControlBasis):
         influence = influence / influence.max(dim=0).values.clamp(min=1e-12)
         return influence
 
-    def n_modes(self):
+    @property
+    def n_modes(self) -> int:
         return self.actuator_grid.n_actuators_x * self.actuator_grid.n_actuators_y
 
 
@@ -105,7 +106,7 @@ class SquareZonalBasis(ControlBasis):
         dx = x_flat[:, None] - ax_flat[None, :]
         dy = y_flat[:, None] - ay_flat[None, :]
 
-        influence = torch.zeros(self.pixel_grid.ny * self.pixel_grid.nx, self.n_modes())
+        influence = torch.zeros(self.pixel_grid.ny * self.pixel_grid.nx, self.n_modes)
         influence[
             (torch.abs(dx) < self.influence_width)
             & (torch.abs(dy) < self.influence_width)
@@ -113,7 +114,8 @@ class SquareZonalBasis(ControlBasis):
 
         return influence
 
-    def n_modes(self):
+    @property
+    def n_modes(self) -> int:
         return self.actuator_grid.n_actuators_x * self.actuator_grid.n_actuators_y
 
 
@@ -168,7 +170,8 @@ class SquarePTTZonalBasis(ControlBasis):
 
         return influence
 
-    def n_modes(self):
+    @property
+    def n_modes(self) -> int:
         return 3 * self.actuator_grid.n_actuators_x * self.actuator_grid.n_actuators_y
 
 
@@ -251,7 +254,8 @@ class FourierBasis(ControlBasis):
 
     #     return modes[:, mask]
 
-    def n_modes(self):
+    @property
+    def n_modes(self) -> int:
         return len(self.frequencies) ** 2
 
 
@@ -272,7 +276,8 @@ class ZernikeBasis(ControlBasis):
 
         return modes[1:, ...].flatten(1, -1).T
 
-    def n_modes(self):
+    @property
+    def n_modes(self) -> int:
         return self.n
 
 
@@ -310,7 +315,7 @@ class DeformableMirror(torch.nn.Module):
         # registered Parameter preserves differentiability and nn.Module.to().
         self._commands = torch.nn.Parameter(
             torch.zeros(
-                self.control_basis.n_modes(),
+                self.control_basis.n_modes,
                 device=self.pixel_grid.device,
             )
         )

--- a/tests/test_control_basis.py
+++ b/tests/test_control_basis.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.optics.elements.deformable_mirror import (
+    ActuatorGrid,
+    ControlBasis,
+    FourierBasis,
+    GaussianZonalBasis,
+    SquarePTTZonalBasis,
+    SquareZonalBasis,
+    ZernikeBasis,
+)
+
+
+class DummyPupil:
+    def __init__(self, grid: Grid):
+        self.transmission = torch.ones((grid.ny, grid.nx))
+
+
+def make_bases():
+    pixel_grid = Grid(nx=5, ny=4, dx=0.1, dy=0.2)
+    actuator_grid = ActuatorGrid(n_actuators_x=2, n_actuators_y=3, pitch=0.1)
+    return [
+        (GaussianZonalBasis(actuator_grid, pixel_grid, 1.0), 6),
+        (SquareZonalBasis(actuator_grid, pixel_grid, 1.0), 6),
+        (SquarePTTZonalBasis(actuator_grid, pixel_grid, 1.0), 18),
+        (FourierBasis(pixel_grid, torch.arange(3), DummyPupil(pixel_grid)), 9),
+        (ZernikeBasis(pixel_grid, n=7), 7),
+    ]
+
+
+@pytest.mark.parametrize("basis, expected", make_bases())
+def test_every_control_basis_exposes_n_modes_as_property(basis, expected):
+    assert basis.n_modes == expected
+    assert isinstance(basis.n_modes, int)
+
+
+def test_n_modes_is_abstract_property_on_base_class():
+    assert isinstance(ControlBasis.__dict__["n_modes"], property)
+    assert ControlBasis.__dict__["n_modes"].fget.__isabstractmethod__

--- a/tests/test_deformable_mirror_commands.py
+++ b/tests/test_deformable_mirror_commands.py
@@ -21,6 +21,7 @@ class TwoPixelBasis(ControlBasis):
         matrix[1, 1] = 1.0
         return matrix
 
+    @property
     def n_modes(self) -> int:
         return 2
 

--- a/tutorials/05_interaction_matrix_modal.ipynb
+++ b/tutorials/05_interaction_matrix_modal.ipynb
@@ -525,6 +525,7 @@
         "    def build_command_matrix(self):\n",
         "        return self.base_command_matrix @ self.eigen_commands\n",
         "\n",
+        "    @property\n",
         "    def n_modes(self):\n",
         "        return self.eigen_commands.shape[1]\n",
         "\n",


### PR DESCRIPTION
## Résumé

- adopte définitivement l’API publique `basis.n_modes` ;
- conserve `n_modes` comme propriété abstraite dans `ControlBasis` ;
- convertit `GaussianZonalBasis`, `SquareZonalBasis`, `SquarePTTZonalBasis`, `FourierBasis` et `ZernikeBasis` vers cette propriété ;
- met à jour `DeformableMirror` et `SquareZonalBasis` pour ne plus appeler `n_modes()` ;
- met à jour la base personnalisée du tutoriel modal et celle des tests DM ;
- ajoute un test contractuel couvrant toutes les bases intégrées.

## Changement d’API

```python
# avant
basis.n_modes()

# maintenant
basis.n_modes
```

## Validation

```text
71 passed, 2 skipped
```

Les deux skips correspondent aux tests CUDA conditionnels sur une machine sans CUDA.

Closes #12.