### PR TITLE
Fix detector ADC digitization

### DIFF
--- a/fiatlux/optics/detector.py
+++ b/fiatlux/optics/detector.py
@@ -15,7 +15,7 @@ class Detector:
         dark_current: float = 0,
         offset: int = 0,
         bitdepth: int = 16,
-        binarize: bool = False,
+        digitize: bool = False,
         sensitivity: float = 1.0,
         random_seed: int = 0,
         name: str = "",
@@ -27,8 +27,14 @@ class Detector:
         self.readout_noise_variance = readout_noise_variance
         self.dark_current = dark_current
         self.offset = offset
+        if (
+            not isinstance(bitdepth, int)
+            or isinstance(bitdepth, bool)
+            or bitdepth < 1
+        ):
+            raise ValueError("bitdepth must be a positive integer.")
         self.bitdepth = bitdepth
-        self.binarize = binarize
+        self.digitize = digitize
         self.sensitivity = sensitivity
         self.random_seed = random_seed
         self.generator = torch.Generator().manual_seed(random_seed)
@@ -73,20 +79,16 @@ class Detector:
     def photons_to_electrons(self, photons: torch.Tensor):
         return self.quantum_efficiency * photons
 
-    def electrons_to_ADUs(self, electrons: torch.Tensor):
-        # Convert to ADU and add baseline
-        max_adu = int(2**self.bitdepth - 1)
-        adu = torch.floor(electrons * self.sensitivity)  # Convert to discrete numbers
+    def electrons_to_adus(self, electrons: torch.Tensor) -> torch.Tensor:
+        """Digitize electrons into integer ADUs in the configured ADC range.
 
-        adu += self.offset
-        # models pixel saturation
-        adu[adu > max_adu] = max_adu
-
-        # Transform to 16 bit image
-        adu *= 2 ** (16 - self.bitdepth)
-        adu = adu.type(torch.int16)
-
-        return adu
+        Gain and offset are applied before values are clipped to
+        ``[0, 2**bitdepth - 1]``. ``int64`` is used so a 16-bit ADC can safely
+        represent its full range, including 65535.
+        """
+        max_adu = 2**self.bitdepth - 1
+        adus = torch.floor(electrons * self.sensitivity) + self.offset
+        return adus.clamp(0, max_adu).to(torch.int64)
 
     def add_noise(self, photons):
         """
@@ -108,7 +110,7 @@ class Detector:
         electrons = self.add_readout_noise(electrons=electrons)
 
         # Convert to ADU and add baseline
-        if self.binarize:
-            return self.electrons_to_ADUs(electrons=electrons)
+        if self.digitize:
+            return self.electrons_to_adus(electrons=electrons)
 
         return electrons

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.optics.detector import Detector
+
+
+def make_detector(**kwargs) -> Detector:
+    return Detector(Grid(nx=3, ny=2, dx=0.1, dy=0.2), **kwargs)
+
+
+def test_16_bit_adc_preserves_the_full_unsigned_range_without_overflow():
+    detector = make_detector(bitdepth=16, digitize=True)
+    electrons = torch.tensor([0.0, 32767.0, 32768.0, 65535.0, 65536.0])
+
+    adus = detector.electrons_to_adus(electrons)
+
+    assert adus.dtype == torch.int64
+    torch.testing.assert_close(
+        adus,
+        torch.tensor([0, 32767, 32768, 65535, 65535], dtype=torch.int64),
+    )
+
+
+def test_adc_clips_negative_values_before_integer_conversion():
+    detector = make_detector(bitdepth=16, digitize=True)
+
+    adus = detector.electrons_to_adus(torch.tensor([-10.0, -0.1, 0.0]))
+
+    torch.testing.assert_close(adus, torch.zeros(3, dtype=torch.int64))
+
+
+def test_adc_applies_sensitivity_and_offset_before_clipping():
+    detector = make_detector(
+        bitdepth=8,
+        digitize=True,
+        sensitivity=2.0,
+        offset=10,
+    )
+
+    adus = detector.electrons_to_adus(torch.tensor([1.9, 200.0]))
+
+    torch.testing.assert_close(adus, torch.tensor([13, 255], dtype=torch.int64))
+
+
+def test_lower_bitdepth_is_not_rescaled_to_a_16_bit_container():
+    detector = make_detector(bitdepth=12, digitize=True)
+
+    adus = detector.electrons_to_adus(torch.tensor([4095.0]))
+
+    assert adus.item() == 4095
+
+
+def test_digitize_controls_whether_adc_conversion_is_applied():
+    photons = torch.tensor([1.5, 2.5])
+
+    analog = make_detector(digitize=False).add_noise(photons)
+    digital = make_detector(digitize=True).add_noise(photons)
+
+    assert analog.is_floating_point()
+    assert digital.dtype == torch.int64
+    torch.testing.assert_close(digital, torch.tensor([1, 2], dtype=torch.int64))
+
+
+@pytest.mark.parametrize("bitdepth", [0, -1, 1.5, True])
+def test_invalid_bitdepth_is_rejected(bitdepth):
+    with pytest.raises(ValueError, match="bitdepth must be a positive integer"):
+        make_detector(bitdepth=bitdepth)
+
+
+def test_legacy_binarize_option_is_no_longer_accepted():
+    with pytest.raises(TypeError):
+        make_detector(binarize=True)


### PR DESCRIPTION
## Résumé

- remplace l’option trompeuse `binarize` par `digitize` ;
- renomme la conversion en `electrons_to_adus()` ;
- applique gain et offset avant la saturation ADC ;
- borne explicitement les valeurs dans `[0, 2**bitdepth - 1]`, y compris les valeurs négatives dues au bruit de lecture ;
- renvoie des entiers `torch.int64`, capables de représenter tout l’intervalle d’un ADC 16 bits sans overflow ;
- supprime la remise à l’échelle implicite des détecteurs de plus faible profondeur vers un conteneur 16 bits ;
- valide que `bitdepth` est un entier strictement positif.

## Changement d’API

```python
detector = Detector(grid, bitdepth=16, digitize=True)
```

Avec ce contrat, `65535` reste bien `65535` au lieu de devenir `-1` comme avec l’ancien `torch.int16`.

## Validation

```text
81 passed, 2 skipped
```

Les tests couvrent les bornes `32767`, `32768`, `65535`, les saturations basse et haute, le gain, l’offset et les ADC 8/12/16 bits.

Closes #9.