### PR TITLE
Fix detector photon-count normalization

### DIFF
--- a/fiatlux/optics/detector.py
+++ b/fiatlux/optics/detector.py
@@ -20,6 +20,14 @@ class Detector:
         random_seed: int = 0,
         name: str = "",
     ):
+        if exposure_time < 0:
+            raise ValueError("exposure_time must be non-negative.")
+        if not 0 <= quantum_efficiency <= 1:
+            raise ValueError("quantum_efficiency must be between 0 and 1.")
+        if readout_noise_variance < 0:
+            raise ValueError("readout_noise_variance must be non-negative.")
+        if dark_current < 0:
+            raise ValueError("dark_current must be non-negative.")
         self.grid = grid
         self.exposure_time = exposure_time
         self.quantum_efficiency = quantum_efficiency
@@ -42,30 +50,42 @@ class Detector:
         self.image_buffer = None
 
     def acquire(self, field: Field) -> torch.Tensor:
-        self.image_buffer = self.add_noise(
-            torch.sum(
-                (self.grid.dx * self.grid.dy) * torch.abs(field.complex_amplitude) ** 2,
-                dim=0,
-            )
-        )
+        """Integrate a photon-rate-density field over pixel area and time.
 
-    def add_photon_noise(self, photons):
+        ``field.intensity()`` is interpreted as photons / s / m² in each
+        wavelength channel. The returned image contains electrons, or ADUs
+        when digitization is enabled.
+        """
+        photon_rate = torch.sum(field.intensity(), dim=0) * (
+            self.grid.dx * self.grid.dy
+        )
+        photon_counts = photon_rate * self.exposure_time
+        self.image_buffer = self.add_noise(
+            photon_counts
+        )
+        return self.image_buffer
+
+    def add_photon_noise(self, expected_electrons: torch.Tensor) -> torch.Tensor:
+        """Draw detected photoelectrons from their Poisson distribution."""
         return torch.poisson(
-            photons,
+            expected_electrons,
             generator=self.generator,
         )
 
     def add_dark_noise(self, electrons: torch.Tensor):
-        dark_noise = (self.dark_current * self.exposure_time) * torch.ones(
-            electrons.shape
+        """Add Poisson dark electrons from a rate in e-/pixel/s."""
+        expected_dark_electrons = torch.full_like(
+            electrons,
+            self.dark_current * self.exposure_time,
         )
         dark_noise = torch.poisson(
-            dark_noise,
+            expected_dark_electrons,
             generator=self.generator,
         )
         return electrons + dark_noise
 
     def add_readout_noise(self, electrons: torch.Tensor):
+        """Add zero-mean Gaussian read noise with variance in electrons²."""
         return (
             torch.normal(
                 mean=0,
@@ -90,18 +110,11 @@ class Detector:
         adus = torch.floor(electrons * self.sensitivity) + self.offset
         return adus.clamp(0, max_adu).to(torch.int64)
 
-    def add_noise(self, photons):
-        """
-        CMOS noise simulation following https://arxiv.org/pdf/1412.4031.pdf
-        """
-        # manage photon noise
-        if self.photon_noise == True:
-            photons = self.add_photon_noise(photons=photons)
-        else:
-            photons = photons
-
-        # convert photons to electrons
-        electrons = self.photons_to_electrons(photons=photons)
+    def add_noise(self, photon_counts: torch.Tensor) -> torch.Tensor:
+        """Convert integrated photon counts through the detector pipeline."""
+        electrons = self.photons_to_electrons(photons=photon_counts)
+        if self.photon_noise:
+            electrons = self.add_photon_noise(expected_electrons=electrons)
 
         # add the dark noise to electrons
         electrons = self.add_dark_noise(electrons=electrons)

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,12 +1,29 @@
+from unittest.mock import patch
+
 import pytest
 import torch
 
+from fiatlux.core.field import Field
 from fiatlux.core.grid import Grid
+from fiatlux.core.spectrum import Band, Spectrum
 from fiatlux.optics.detector import Detector
 
 
 def make_detector(**kwargs) -> Detector:
     return Detector(Grid(nx=3, ny=2, dx=0.1, dy=0.2), **kwargs)
+
+
+def make_field(grid: Grid, intensity_per_channel: torch.Tensor) -> Field:
+    n_wavelengths = len(intensity_per_channel)
+    spectrum = Spectrum(
+        magnitude=0,
+        band=Band(central_wavelength=1e-6, delta_wavelength=0.1e-6, f0=1),
+        samples=n_wavelengths,
+    )
+    amplitude = intensity_per_channel.sqrt()[:, None, None].expand(
+        -1, grid.ny, grid.nx
+    )
+    return Field(amplitude, grid, spectrum)
 
 
 def test_16_bit_adc_preserves_the_full_unsigned_range_without_overflow():
@@ -71,3 +88,89 @@ def test_invalid_bitdepth_is_rejected(bitdepth):
 def test_legacy_binarize_option_is_no_longer_accepted():
     with pytest.raises(TypeError):
         make_detector(binarize=True)
+
+
+def test_acquire_integrates_spectral_rate_over_pixel_area_and_exposure_time():
+    detector = make_detector(exposure_time=2.0)
+    field = make_field(detector.grid, torch.tensor([10.0, 15.0]))
+
+    image = detector.acquire(field)
+
+    expected = torch.full((2, 3), 25.0 * 0.1 * 0.2 * 2.0)
+    torch.testing.assert_close(image, expected)
+    assert image is detector.image_buffer
+
+
+def test_doubling_exposure_time_doubles_source_counts():
+    short = make_detector(exposure_time=1.0)
+    long = make_detector(exposure_time=2.0)
+    field = make_field(short.grid, torch.tensor([10.0]))
+
+    torch.testing.assert_close(long.acquire(field), 2 * short.acquire(field))
+
+
+def test_quantum_efficiency_scales_expected_electrons_once():
+    ideal = make_detector(exposure_time=1.0, quantum_efficiency=1.0)
+    half_qe = make_detector(exposure_time=1.0, quantum_efficiency=0.5)
+    field = make_field(ideal.grid, torch.tensor([100.0]))
+
+    torch.testing.assert_close(half_qe.acquire(field), 0.5 * ideal.acquire(field))
+
+
+def test_zero_field_produces_zero_source_counts_without_detector_noise():
+    detector = make_detector(exposure_time=10.0)
+    field = make_field(detector.grid, torch.tensor([0.0]))
+
+    torch.testing.assert_close(detector.acquire(field), torch.zeros((2, 3)))
+
+
+def test_photon_noise_receives_integrated_detected_electron_counts():
+    detector = make_detector(
+        exposure_time=2.0,
+        quantum_efficiency=0.5,
+        photon_noise=True,
+    )
+    field = make_field(detector.grid, torch.tensor([100.0]))
+    poisson_inputs = []
+
+    def deterministic_poisson(values, generator=None):
+        poisson_inputs.append(values.clone())
+        return values
+
+    with patch("torch.poisson", side_effect=deterministic_poisson):
+        detector.acquire(field)
+
+    expected_photoelectrons = torch.full((2, 3), 100.0 * 0.1 * 0.2 * 2.0 * 0.5)
+    torch.testing.assert_close(poisson_inputs[0], expected_photoelectrons)
+
+
+def test_dark_current_is_a_rate_per_pixel_and_read_noise_uses_variance():
+    detector = make_detector(
+        exposure_time=2.0,
+        dark_current=3.0,
+        readout_noise_variance=4.0,
+    )
+    electrons = torch.zeros((2, 3))
+
+    with patch("torch.poisson", side_effect=lambda values, generator=None: values):
+        darkened = detector.add_dark_noise(electrons)
+    torch.testing.assert_close(darkened, torch.full((2, 3), 6.0))
+
+    with patch("torch.normal", return_value=torch.zeros((2, 3))) as normal:
+        detector.add_readout_noise(electrons)
+    assert normal.call_args.kwargs["std"] == 2.0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"exposure_time": -1},
+        {"quantum_efficiency": -0.1},
+        {"quantum_efficiency": 1.1},
+        {"dark_current": -1},
+        {"readout_noise_variance": -1},
+    ],
+)
+def test_invalid_physical_detector_parameters_are_rejected(kwargs):
+    with pytest.raises(ValueError):
+        make_detector(**kwargs)


### PR DESCRIPTION
## Résumé

Le détecteur interprète désormais explicitement `Field.intensity()` comme une densité de débit photonique par canal spectral, en photons / s / m².

La chaîne de détection devient :

```text
somme spectrale
→ multiplication par l’aire du pixel
→ multiplication par le temps de pose
→ rendement quantique
→ bruit de photons
→ courant d’obscurité
→ bruit de lecture
→ numérisation éventuelle
```

## Corrections

- le signal incident est maintenant multiplié par `exposure_time` ;
- l’aire physique du pixel `dx * dy` est appliquée exactement une fois ;
- la QE convertit les photons intégrés en photoélectrons avant le tirage de Poisson ;
- le bruit photonique utilise donc des comptes intégrés, pas un débit ;
- `dark_current` est documenté et appliqué en e⁻/pixel/s ;
- `readout_noise_variance` est utilisé en e⁻² ;
- `acquire()` renvoie désormais l’image en plus de remplir `image_buffer` ;
- les paramètres physiques négatifs et les QE hors `[0, 1]` sont rejetés.

## Validation

```text
92 passed, 2 skipped
```

Les tests vérifient notamment que doubler le temps de pose double le signal, que `QE=0.5` divise les photoélectrons par deux, qu’un champ nul ne crée aucun compte source et que le Poisson reçoit bien les photoélectrons intégrés.

Closes #10.