### PR TITLE
Fix source photometric normalization

### DIFF
--- a/fiatlux/core/source.py
+++ b/fiatlux/core/source.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, field
-from typing import Optional
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+import math
 
 import torch
 
@@ -20,8 +20,31 @@ class Source(ABC):
     def __init__(self, spectrum: Spectrum):
         self.spectrum = spectrum
 
-    def _get_fluxes(self, grid: Grid) -> torch.Tensor:
-        return self.spectrum.fluxes * grid.dx * grid.dy
+    def _normalize_spatial_amplitude(
+        self,
+        spatial_amplitude: torch.Tensor,
+        grid: Grid,
+        spectrum: Spectrum,
+    ) -> torch.Tensor:
+        """Normalize a spatial amplitude to each channel's photon flux.
+
+        The returned field satisfies
+        ``sum(abs(E[channel])**2) * dx * dy == spectrum.fluxes[channel]``.
+        """
+        integrated_intensity = (
+            spatial_amplitude.abs().square().sum() * grid.dx * grid.dy
+        )
+        if not torch.isfinite(integrated_intensity) or integrated_intensity <= 0:
+            raise ValueError("The source spatial profile must have finite positive power.")
+        if torch.any(spectrum.fluxes < 0) or not torch.isfinite(spectrum.fluxes).all():
+            raise ValueError("Spectrum fluxes must be finite and non-negative.")
+
+        channel_amplitudes = spectrum.fluxes.sqrt().to(
+            device=grid.device,
+            dtype=spatial_amplitude.real.dtype,
+        )
+        normalized_profile = spatial_amplitude / integrated_intensity.sqrt()
+        return channel_amplitudes[:, None, None] * normalized_profile
 
     @abstractmethod
     def generate_field(self, grid: Grid) -> Field: ...
@@ -42,10 +65,16 @@ class PlaneWave(Source):
         super().__init__(spectrum)
 
     def generate_field(self, grid: Grid) -> Field:
+        spectrum = self.spectrum.to(grid.device)
+        spatial_amplitude = torch.ones(
+            (grid.ny, grid.nx),
+            dtype=torch.complex64,
+            device=grid.device,
+        )
         return Field(
-            self._get_fluxes(grid=grid)[:, None, None] * torch.ones((grid.ny, grid.nx)),
+            self._normalize_spatial_amplitude(spatial_amplitude, grid, spectrum),
             grid,
-            self.spectrum,
+            spectrum,
         )
 
     @property
@@ -60,20 +89,23 @@ class GaussianSource(Source):
         spectrum: Spectrum,
         waist: float,
     ):
+        if not math.isfinite(waist) or waist <= 0:
+            raise ValueError("waist must be a positive finite length.")
         self.waist = waist
         super().__init__(spectrum)
 
     def generate_field(self, grid: Grid) -> Field:
         x, y = grid.meshgrid()
-        n_wavelengths = len(self.spectrum.wavelengths)
-
-        envelope = (
-            (torch.exp(-(x**2 + y**2) / self.waist**2))
-            .to(torch.complex64)
-            .unsqueeze(0)
-            .expand(n_wavelengths, -1, -1)
+        spectrum = self.spectrum.to(grid.device)
+        spatial_amplitude = torch.exp(
+            -(x**2 + y**2) / self.waist**2
+        ).to(torch.complex64)
+        amplitude = self._normalize_spatial_amplitude(
+            spatial_amplitude,
+            grid,
+            spectrum,
         )
-        return Field(envelope, grid, self.spectrum)
+        return Field(amplitude, grid, spectrum)
 
     @property
     def _symbol(self) -> str:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,95 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.core.source import GaussianSource, PlaneWave
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.detector import Detector
+
+
+def make_spectrum(samples=3) -> Spectrum:
+    return Spectrum(
+        magnitude=2,
+        band=Band(
+            central_wavelength=1.1e-6,
+            delta_wavelength=0.2e-6,
+            f0=1e10,
+        ),
+        samples=samples,
+    )
+
+
+def integrated_spectral_flux(field) -> torch.Tensor:
+    return field.intensity().sum(dim=(-2, -1)) * field.grid.dx * field.grid.dy
+
+
+@pytest.mark.parametrize("source_type", [PlaneWave, GaussianSource])
+def test_each_source_integrates_to_requested_flux_per_wavelength(source_type):
+    grid = Grid(nx=7, ny=5, dx=0.03, dy=0.05)
+    spectrum = make_spectrum()
+    source = (
+        source_type(spectrum)
+        if source_type is PlaneWave
+        else source_type(spectrum, waist=0.08)
+    )
+
+    field = source.generate_field(grid)
+
+    assert field.complex_amplitude.shape == (3, 5, 7)
+    assert field.complex_amplitude.is_complex()
+    torch.testing.assert_close(
+        integrated_spectral_flux(field),
+        spectrum.fluxes,
+        rtol=1e-6,
+        atol=0,
+    )
+
+
+def test_plane_and_gaussian_sources_have_the_same_total_photon_rate():
+    grid = Grid(nx=9, ny=7, dx=0.02, dy=0.03)
+    spectrum = make_spectrum(samples=4)
+
+    plane = PlaneWave(spectrum).generate_field(grid)
+    gaussian = GaussianSource(spectrum, waist=0.06).generate_field(grid)
+
+    plane_rate = plane.intensity().sum() * grid.dx * grid.dy
+    gaussian_rate = gaussian.intensity().sum() * grid.dx * grid.dy
+    torch.testing.assert_close(plane_rate, spectrum.fluxes.sum(), rtol=1e-6, atol=0)
+    torch.testing.assert_close(gaussian_rate, plane_rate, rtol=1e-6, atol=0)
+
+
+def test_plane_wave_normalization_is_independent_of_grid_sampling():
+    spectrum = make_spectrum(samples=1)
+    coarse = Grid(nx=5, ny=4, dx=0.1, dy=0.1)
+    fine = Grid(nx=10, ny=8, dx=0.05, dy=0.05)
+
+    coarse_rate = integrated_spectral_flux(PlaneWave(spectrum).generate_field(coarse))
+    fine_rate = integrated_spectral_flux(PlaneWave(spectrum).generate_field(fine))
+
+    torch.testing.assert_close(coarse_rate, spectrum.fluxes, rtol=1e-6, atol=0)
+    torch.testing.assert_close(fine_rate, spectrum.fluxes, rtol=1e-6, atol=0)
+
+
+def test_source_to_detector_applies_pixel_area_exactly_once():
+    grid = Grid(nx=7, ny=5, dx=0.03, dy=0.05)
+    spectrum = make_spectrum()
+    field = PlaneWave(spectrum).generate_field(grid)
+    detector = Detector(grid, exposure_time=1.0, quantum_efficiency=1.0)
+
+    image = detector.acquire(field)
+
+    torch.testing.assert_close(image.sum(), spectrum.fluxes.sum(), rtol=1e-6, atol=0)
+
+
+@pytest.mark.parametrize("waist", [0.0, -1.0, float("inf"), float("nan")])
+def test_gaussian_source_rejects_invalid_waist(waist):
+    with pytest.raises(ValueError, match="waist must be a positive finite length"):
+        GaussianSource(make_spectrum(), waist=waist)
+
+
+def test_source_rejects_invalid_spectral_flux():
+    spectrum = make_spectrum(samples=1)
+    spectrum.fluxes[0] = -1
+
+    with pytest.raises(ValueError, match="fluxes must be finite and non-negative"):
+        PlaneWave(spectrum).generate_field(Grid(nx=3, ny=2, dx=0.1, dy=0.2))


### PR DESCRIPTION
## Convention physique

Pour chaque canal spectral, les sources produisent désormais un champ vérifiant

```text
sum(|E_lambda|²) * dx * dy = spectral_flux[lambda]
```

Ainsi, `|E|²` est une densité de débit photonique en photons / s / m² et `Spectrum.fluxes` contient le débit photonique total de chaque canal.

## Corrections

- `PlaneWave` utilise la racine carrée du flux et normalise son profil sur l’aire totale de la grille ;
- `GaussianSource` normalise discrètement son profil sur la grille avant d’appliquer les poids spectraux ;
- chaque canal reçoit exactement son propre flux spectral ;
- les champs produits sont complexes et directement compatibles avec la propagation optique ;
- le spectre est placé sur le device de la grille ;
- les flux négatifs/non finis et les waist gaussiens invalides sont rejetés ;
- aucune aire de pixel n’est incorporée dans l’amplitude de la source.

## Validation

```text
102 passed, 2 skipped
```

Les tests couvrent les grilles rectangulaires, plusieurs canaux spectraux, plusieurs résolutions, l’égalité des flux totaux plane/gaussienne et une chaîne source → détecteur démontrant que l’aire du pixel est appliquée exactement une fois.

Closes #6.