### PR TITLE
Define and validate Field physical units

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,25 @@ Instead of writing a new propagation script for every experiment, Fiatlux separa
 Fiatlux is built around **PyTorch tensors**, allowing optical simulations to integrate naturally with modern numerical optimization and machine-learning workflows.
 
 > [!NOTE]
-> The `fiatlux2.0` branch is under active development. The API and physical normalization conventions are still being consolidated.
+> Fiatlux is active research software and its API may still evolve. The physical normalization below is part of the supported core contract.
+
+### Physical field normalization
+
+In every spatial optical plane, Fiatlux uses the following convention for each wavelength channel:
+
+```text
+Field.complex_amplitude       sqrt(photons / s / m²)
+Field.intensity() = |E|²      photons / s / m²
+Spectrum.fluxes               photons / s per wavelength channel
+```
+
+The photon rate carried by channel `k` is therefore the discrete spatial integral
+
+```python
+photon_rate_k = field.intensity()[k].sum() * field.grid.dx * field.grid.dy
+```
+
+`PlaneWave` and `GaussianSource` are normalized so this integral equals `spectrum.fluxes[k]`. Lossless propagation preserves that integral when the input and output grids form a correctly sampled Fourier pair. A detector then integrates the spectral photon-rate density over wavelength channels, physical pixel area and exposure time before applying quantum efficiency and detector noise.
 
 ---
 

--- a/fiatlux/core/field.py
+++ b/fiatlux/core/field.py
@@ -15,11 +15,21 @@ if TYPE_CHECKING:
 
 @dataclass
 class Field:
+    """Polychromatic scalar optical field sampled on a physical grid.
+
+    ``complex_amplitude`` has shape ``(n_wavelengths, ny, nx)``. In a spatial
+    plane its units are ``sqrt(photons / s / m²)``, so :meth:`intensity`
+    returns a photon-rate density in ``photons / s / m²`` for each wavelength
+    channel. Consequently, the photon rate in channel ``k`` is
+    ``intensity()[k].sum() * grid.dx * grid.dy``.
+    """
+
     complex_amplitude: torch.Tensor
     grid: BaseGrid
     spectrum: Spectrum
 
     def intensity(self) -> torch.Tensor:
+        """Return spectral photon-rate density ``|E|²`` in photons / s / m²."""
         return self.complex_amplitude.abs() ** 2
 
     def phase(self) -> torch.Tensor:
@@ -120,7 +130,7 @@ class Field:
         axs[0].set_title(
             f"Intensity at λ={self.spectrum.wavelengths[wavelength_index]:.2e} m"
         )
-        fig.colorbar(pcm, ax=axs[0], label="Intensity (in photon)")
+        fig.colorbar(pcm, ax=axs[0], label="Photon rate density (photons/s/m²)")
 
         pcm = axs[1].imshow(
             self.phase()[wavelength_index],

--- a/tests/test_physical_units.py
+++ b/tests/test_physical_units.py
@@ -1,0 +1,86 @@
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.core.source import PlaneWave
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.detector import Detector
+from fiatlux.optics.propagator import IdentityPropagator, MFTPropagator
+from fiatlux.system.optical_system import SerialSystem
+
+
+def make_monochromatic_spectrum(wavelength=1e-6) -> Spectrum:
+    return Spectrum(
+        magnitude=0,
+        band=Band(
+            central_wavelength=wavelength,
+            delta_wavelength=0.0,
+            f0=3.68e8,
+        ),
+        samples=1,
+    )
+
+
+def integrated_photon_rate(field) -> torch.Tensor:
+    return field.intensity().sum() * field.grid.dx * field.grid.dy
+
+
+def test_plane_wave_system_matches_analytical_detector_counts():
+    grid = Grid(nx=8, ny=6, dx=0.1, dy=0.2)
+    spectrum = make_monochromatic_spectrum()
+    source = PlaneWave(spectrum)
+    identity = IdentityPropagator(grid)
+    detector = Detector(
+        grid,
+        exposure_time=2.5,
+        quantum_efficiency=0.4,
+    )
+    system = SerialSystem(elements=[identity])
+
+    result = system.run(source, detector)
+
+    expected_photon_rate = spectrum.fluxes.sum()
+    expected_electrons = expected_photon_rate * 2.5 * 0.4
+    torch.testing.assert_close(
+        integrated_photon_rate(result.field_at(identity)),
+        expected_photon_rate,
+        rtol=1e-6,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        detector.image_buffer.sum(),
+        expected_electrons,
+        rtol=1e-6,
+        atol=0,
+    )
+
+
+def test_mft_preserves_flux_on_a_discrete_fourier_grid():
+    n_pixels = 8
+    wavelength = 1e-6
+    focal_length = 2.0
+    input_spacing = 0.1
+    output_spacing = wavelength * focal_length / (n_pixels * input_spacing)
+    input_grid = Grid(
+        nx=n_pixels,
+        ny=n_pixels,
+        dx=input_spacing,
+        dy=input_spacing,
+    )
+    output_grid = Grid(
+        nx=n_pixels,
+        ny=n_pixels,
+        dx=output_spacing,
+        dy=output_spacing,
+    )
+    input_field = PlaneWave(
+        make_monochromatic_spectrum(wavelength)
+    ).generate_field(input_grid)
+
+    output_field = MFTPropagator(focal_length, output_grid).apply(input_field)
+
+    torch.testing.assert_close(
+        integrated_photon_rate(output_field),
+        integrated_photon_rate(input_field),
+        rtol=1e-5,
+        atol=0,
+    )


### PR DESCRIPTION
## Convention physique

Dans tout plan spatial, pour chaque canal spectral :

```text
Field.complex_amplitude       sqrt(photons / s / m²)
Field.intensity() = |E|²      photons / s / m²
Spectrum.fluxes               photons / s par canal
```

Le débit photonique d’un canal est donc :

```python
photon_rate = field.intensity()[k].sum() * grid.dx * grid.dy
```

## Modifications

- documente forme, axes et unités directement dans `Field` ;
- documente les unités renvoyées par `Field.intensity()` ;
- corrige le libellé physique de la colorbar de `Field.plot()` ;
- ajoute le contrat photométrique au README ;
- relie explicitement la normalisation des sources, la conservation par propagation et l’intégration du détecteur.

## Validations analytiques

- une onde plane traversant un `SerialSystem` identité produit exactement le nombre d’électrons prédit par flux × temps de pose × QE ;
- une MFT sur une paire de grilles de Fourier avec `du = λf / (N dx)` conserve l’intégrale spatiale de `|E|²` conformément à Parseval.

```text
104 passed, 2 skipped
```

Closes #5.