### PR TITLE
Standardize rectangular field and MFT axis conventions

### DIFF
--- a/examples/rectangular_grid_validation.ipynb
+++ b/examples/rectangular_grid_validation.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visual validation of rectangular grids\n",
+    "\n",
+    "This notebook illustrates the conventions tested by PR #50:\n",
+    "\n",
+    "- fields are shaped `(n_wavelengths, ny, nx)`;\n",
+    "- x is the horizontal, last tensor axis;\n",
+    "- y is the vertical, second-to-last tensor axis;\n",
+    "- tip shifts the PSF along x and tilt shifts it along y;\n",
+    "- chromatic field stops are shaped `(n_wavelengths, ny, nx)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "\n",
+    "from fiatlux import (\n",
+    "    CircularAperture,\n",
+    "    Grid,\n",
+    "    MFTPropagator,\n",
+    "    PlaneWave,\n",
+    "    ShanonFieldStop,\n",
+    "    Spectrum,\n",
+    "    TipTilt,\n",
+    ")\n",
+    "from fiatlux.core.spectrum import Band"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Deliberately rectangular pupil and focal grids.\n",
+    "nx_in, ny_in = 96, 64\n",
+    "nx_out, ny_out = 128, 80\n",
+    "diameter_x, diameter_y = 1.0, 0.8\n",
+    "wavelength = 1.0e-6\n",
+    "focal_length = 2.0\n",
+    "\n",
+    "pupil_grid = Grid(\n",
+    "    nx=nx_in,\n",
+    "    ny=ny_in,\n",
+    "    dx=diameter_x / nx_in,\n",
+    "    dy=diameter_y / ny_in,\n",
+    ")\n",
+    "focal_grid = Grid(\n",
+    "    nx=nx_out,\n",
+    "    ny=ny_out,\n",
+    "    dx=wavelength * focal_length / (nx_in * pupil_grid.dx),\n",
+    "    dy=wavelength * focal_length / (ny_in * pupil_grid.dy),\n",
+    ")\n",
+    "\n",
+    "spectrum = Spectrum(\n",
+    "    magnitude=0,\n",
+    "    band=Band(wavelength, 0.0, 3.68e8),\n",
+    "    samples=1,\n",
+    ")\n",
+    "source = PlaneWave(spectrum)\n",
+    "aperture = CircularAperture(pupil_grid, radius=0.35)\n",
+    "propagator = MFTPropagator(focal_length, focal_grid)\n",
+    "\n",
+    "entrance_field = source.generate_field(pupil_grid)\n",
+    "pupil_field = aperture.apply(entrance_field)\n",
+    "focal_field = propagator.apply(pupil_field)\n",
+    "psf = focal_field.intensity()[0]\n",
+    "\n",
+    "print('Entrance field:', tuple(entrance_field.complex_amplitude.shape))\n",
+    "print('Focal field:   ', tuple(focal_field.complex_amplitude.shape))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 4), constrained_layout=True)\n",
+    "\n",
+    "axes[0].imshow(\n",
+    "    pupil_field.intensity()[0].cpu(),\n",
+    "    origin='lower',\n",
+    "    extent=[pupil_grid.x.min(), pupil_grid.x.max(), pupil_grid.y.min(), pupil_grid.y.max()],\n",
+    ")\n",
+    "axes[0].set(title='Rectangular array, circular pupil', xlabel='x (m)', ylabel='y (m)')\n",
+    "\n",
+    "axes[1].imshow((psf / psf.max()).cpu(), origin='lower', cmap='magma')\n",
+    "axes[1].set(title='Normalized focal-plane PSF', xlabel='x pixel', ylabel='y pixel')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tip and tilt orientation\n",
+    "\n",
+    "The OPD ramps below correspond to exactly one Fourier bin. The expected peaks are one pixel to the right for tip and one pixel upward for tilt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def shifted_psf(tip=0.0, tilt=0.0):\n",
+    "    ramp = TipTilt(pupil_grid, tip=tip, tilt=tilt)\n",
+    "    ramped_field = ramp.apply(pupil_field)\n",
+    "    return propagator.apply(ramped_field).intensity()[0]\n",
+    "\n",
+    "tip_one_bin = wavelength / (nx_in * pupil_grid.dx)\n",
+    "tilt_one_bin = wavelength / (ny_in * pupil_grid.dy)\n",
+    "images = [\n",
+    "    ('Reference', shifted_psf()),\n",
+    "    ('Tip: +1 x bin', shifted_psf(tip=tip_one_bin)),\n",
+    "    ('Tilt: +1 y bin', shifted_psf(tilt=tilt_one_bin)),\n",
+    "]\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(13, 4), constrained_layout=True)\n",
+    "for ax, (title, image) in zip(axes, images):\n",
+    "    peak_y, peak_x = torch.unravel_index(image.argmax(), image.shape)\n",
+    "    ax.imshow((image / image.max()).cpu(), origin='lower', cmap='magma')\n",
+    "    ax.scatter(peak_x.cpu(), peak_y.cpu(), marker='+', s=120, c='cyan')\n",
+    "    ax.set_title(f'{title}\\npeak=(y={peak_y.item()}, x={peak_x.item()})')\n",
+    "    ax.set(xlabel='x pixel', ylabel='y pixel')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chromatic rectangular field stop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "polychromatic = Spectrum(\n",
+    "    magnitude=0,\n",
+    "    band=Band(wavelength, 0.4 * wavelength, 3.68e8),\n",
+    "    samples=3,\n",
+    ")\n",
+    "field_stop = ShanonFieldStop(focal_grid)\n",
+    "field_stop.build(polychromatic)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(12, 3.5), constrained_layout=True)\n",
+    "for index, (ax, wl) in enumerate(zip(axes, polychromatic.wavelengths)):\n",
+    "    ax.imshow(field_stop.transmission[index].real.cpu(), origin='lower', vmin=0, vmax=1)\n",
+    "    ax.set_title(f'λ = {wl.item() * 1e9:.0f} nm')\n",
+    "    ax.set(xlabel='x pixel', ylabel='y pixel')\n",
+    "\n",
+    "print('Field-stop transmission:', tuple(field_stop.transmission.shape))\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fiatlux/core/field.py
+++ b/fiatlux/core/field.py
@@ -28,6 +28,40 @@ class Field:
     grid: BaseGrid
     spectrum: Spectrum
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.complex_amplitude, torch.Tensor):
+            raise TypeError("complex_amplitude must be a torch.Tensor.")
+        if self.complex_amplitude.ndim != 3:
+            raise ValueError(
+                "complex_amplitude must have shape (n_wavelengths, ny, nx)."
+            )
+        if self.spectrum.wavelengths.ndim != 1 or self.spectrum.fluxes.ndim != 1:
+            raise ValueError("Spectrum wavelengths and fluxes must be one-dimensional.")
+        if self.spectrum.wavelengths.shape != self.spectrum.fluxes.shape:
+            raise ValueError("Spectrum wavelengths and fluxes must have identical shapes.")
+
+        expected_shape = (
+            len(self.spectrum.wavelengths),
+            self.grid.ny,
+            self.grid.nx,
+        )
+        if self.complex_amplitude.shape != expected_shape:
+            raise ValueError(
+                "complex_amplitude must have shape "
+                f"(n_wavelengths, ny, nx) = {expected_shape}, got "
+                f"{tuple(self.complex_amplitude.shape)}."
+            )
+        devices = {
+            self.complex_amplitude.device,
+            self.spectrum.wavelengths.device,
+            self.spectrum.fluxes.device,
+            self.grid.device,
+        }
+        if len(devices) != 1:
+            raise ValueError(
+                "Field amplitude, spectrum and grid must be on the same device."
+            )
+
     def intensity(self) -> torch.Tensor:
         """Return spectral photon-rate density ``|E|²`` in photons / s / m²."""
         return self.complex_amplitude.abs() ** 2

--- a/fiatlux/core/grid.py
+++ b/fiatlux/core/grid.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+import math
 import torch
 
 
@@ -22,6 +23,22 @@ class Grid(BaseGrid):
     dy: float
     device: torch.device = torch.device("cpu")
 
+    def __post_init__(self) -> None:
+        for name in ("nx", "ny"):
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} must be a positive integer.")
+        for name in ("dx", "dy"):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be a positive finite spacing.")
+        self.device = torch.device(self.device)
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Spatial tensor shape in canonical ``(ny, nx)`` order."""
+        return (self.ny, self.nx)
+
     @property
     def x(self) -> torch.Tensor:
         return (torch.arange(self.nx, device=self.device) - self.nx // 2) * self.dx
@@ -31,6 +48,7 @@ class Grid(BaseGrid):
         return (torch.arange(self.ny, device=self.device) - self.ny // 2) * self.dy
 
     def meshgrid(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return ``(x, y)`` coordinate arrays, both shaped ``(ny, nx)``."""
         return torch.meshgrid(self.x, self.y, indexing="xy")
 
     def to(self, device: torch.device) -> Grid:

--- a/fiatlux/optics/detector.py
+++ b/fiatlux/optics/detector.py
@@ -56,6 +56,8 @@ class Detector:
         wavelength channel. The returned image contains electrons, or ADUs
         when digitization is enabled.
         """
+        if field.grid != self.grid:
+            raise ValueError("Detector grid must match the incoming field grid.")
         photon_rate = torch.sum(field.intensity(), dim=0) * (
             self.grid.dx * self.grid.dy
         )

--- a/fiatlux/optics/elements/deformable_mirror.py
+++ b/fiatlux/optics/elements/deformable_mirror.py
@@ -48,7 +48,7 @@ class GaussianZonalBasis(ControlBasis):
         """
         ag = self.actuator_grid
         pg = self.pixel_grid
-        x, y = pg.meshgrid()  # (nx, ny)
+        x, y = pg.meshgrid()  # (ny, nx)
         x_flat = x.flatten()  # (nx*ny,)
         y_flat = y.flatten()
 
@@ -91,7 +91,7 @@ class SquareZonalBasis(ControlBasis):
         """
         ag = self.actuator_grid
         pg = self.pixel_grid
-        x, y = pg.meshgrid()  # (nx, ny)
+        x, y = pg.meshgrid()  # (ny, nx)
         x_flat = x.flatten()  # (nx*ny,)
         y_flat = y.flatten()
 
@@ -133,7 +133,7 @@ class SquarePTTZonalBasis(ControlBasis):
         """
         ag = self.actuator_grid
         pg = self.pixel_grid
-        x, y = pg.meshgrid()  # (nx, ny)
+        x, y = pg.meshgrid()  # (ny, nx)
         x_flat = x.flatten()  # (nx*ny,)
         y_flat = y.flatten()
 
@@ -186,7 +186,7 @@ class FourierBasis(ControlBasis):
         n_freqs = len(self.frequencies)
 
         # Pixel coordinate grids  (resolution, resolution)
-        x, y = self.pixel_grid.meshgrid()  # (nx, ny)
+        x, y = self.pixel_grid.meshgrid()  # (ny, nx)
 
         # All (freq_x, freq_y) pairs  →  (n_freqs, n_freqs)
         freq_x = self.frequencies[:, None].expand(n_freqs, n_freqs)
@@ -381,6 +381,8 @@ class DeformableMirror(torch.nn.Module):
         )
 
     def apply(self, field: Field) -> Field:
+        if field.grid != self.pixel_grid:
+            raise ValueError("DM pixel grid must match the incoming field grid.")
         self._build(field.spectrum)
 
         return Field(

--- a/fiatlux/optics/elements/field_stop.py
+++ b/fiatlux/optics/elements/field_stop.py
@@ -6,31 +6,45 @@ from fiatlux.optics.elements.mask import Mask
 
 
 class ShanonFieldStop(Mask):
+    """Wavelength-scaled rectangular field stop on a ``(ny, nx)`` grid."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, grid: Grid):
+        self._spectrum: Spectrum | None = None
+        super().__init__(grid=grid)
 
-    def _build_transmission(self, grid: Grid, spectrum: Spectrum):
-        lambda_max = spectrum.wavelengths.max()
+    def build(self, spectrum: Spectrum) -> None:
+        self._spectrum = spectrum
+        try:
+            super().build(spectrum)
+        finally:
+            self._spectrum = None
 
-        x_max = grid.nx
-        y_max = grid.ny
+    def _build_transmission(self) -> None:
+        if self._spectrum is None:
+            raise RuntimeError("ShanonFieldStop.build() requires a Spectrum.")
+        lambda_max = self._spectrum.wavelengths.max()
+        x_limit = self.grid.nx / 2
+        y_limit = self.grid.ny / 2
 
-        x, y = torch.meshgrid(
-            torch.linspace(-x_max, x_max, x_max),
-            torch.linspace(-y_max, y_max, y_max),
+        y, x = torch.meshgrid(
+            torch.arange(self.grid.ny, device=self.grid.device) - self.grid.ny // 2,
+            torch.arange(self.grid.nx, device=self.grid.device) - self.grid.nx // 2,
+            indexing="ij",
         )
 
         self.transmission = torch.stack(
             [
                 (
-                    (x.abs() <= x_max * (wl / lambda_max))
-                    & (y.abs() <= y_max * (wl / lambda_max))
+                    (x.abs() <= x_limit * (wl / lambda_max))
+                    & (y.abs() <= y_limit * (wl / lambda_max))
                 ).to(torch.complex64)
-                for wl in spectrum.wavelengths
+                for wl in self._spectrum.wavelengths
             ],
             dim=0,
-        )  # (n_λ, nx, ny)
+        )
 
-    def _build_opd(self, grid: Grid, spectrum: Spectrum):
-        self.opd = torch.zeros((grid.ny, grid.nx))
+    def _build_opd(self) -> None:
+        self.opd = torch.zeros(
+            self.grid.shape,
+            device=self.grid.device,
+        )

--- a/fiatlux/optics/elements/mask.py
+++ b/fiatlux/optics/elements/mask.py
@@ -42,11 +42,29 @@ class Mask(OpticalElement, ABC):
     def build(self, spectrum: Spectrum) -> None:
         self._build_transmission()
         self._build_opd()
+        expected_spatial_shape = (self.grid.ny, self.grid.nx)
+        allowed_shapes = {
+            expected_spatial_shape,
+            (len(spectrum.wavelengths), *expected_spatial_shape),
+        }
+        for name in ("transmission", "opd"):
+            value = getattr(self, name)
+            if (
+                not isinstance(value, torch.Tensor)
+                or tuple(value.shape) not in allowed_shapes
+            ):
+                raise ValueError(
+                    f"Mask {name} must have shape (ny, nx) or "
+                    f"(n_wavelengths, ny, nx); got "
+                    f"{None if not isinstance(value, torch.Tensor) else tuple(value.shape)}."
+                )
         self.complex_transmission = self.transmission * torch.exp(
             1j * 2 * torch.pi * self.opd / spectrum.wavelengths[:, None, None]
         )
 
     def apply(self, field: Field) -> Field:
+        if field.grid != self.grid:
+            raise ValueError("Mask grid must match the incoming field grid.")
         if self.complex_transmission is None or self.recompute:
             self.build(field.spectrum)
 
@@ -209,13 +227,14 @@ class ProuhetThueMorse(Mask):
         self.transmission = torch.ones((self.grid.ny, self.grid.nx))
 
     def _build_opd(self) -> None:
-        x = torch.arange(self.grid.nx)
-        y = torch.arange(self.grid.ny)
-
-        X, Y = torch.meshgrid(x, y, indexing="ij")
+        y, x = torch.meshgrid(
+            torch.arange(self.grid.ny),
+            torch.arange(self.grid.nx),
+            indexing="ij",
+        )
 
         # XOR-based 2D PTM
-        Z = X ^ Y
+        Z = x ^ y
 
         self.opd = 600e-9 * self.parity_popcount(Z).float()
 

--- a/fiatlux/optics/propagator.py
+++ b/fiatlux/optics/propagator.py
@@ -31,24 +31,33 @@ class MFTPropagator(Propagator):
         return torch.exp(-2j * torch.pi * torch.outer(x, u))  # (nx, mx) — 2D
 
     def apply(self, field: Field) -> Field:
+        if field.grid.device != self.output_grid.device:
+            raise ValueError("MFT input and output grids must be on the same device.")
+
         x, y = field.grid.x, field.grid.y
         u, v = self.output_grid.x, self.output_grid.y
 
-        wavelengths = field.spectrum.wavelengths  # (n_wavelengths,)
+        real_dtype = field.complex_amplitude.real.dtype
+        x = x.to(dtype=real_dtype)
+        y = y.to(dtype=real_dtype)
+        u = u.to(dtype=real_dtype)
+        v = v.to(dtype=real_dtype)
+        wavelengths = field.spectrum.wavelengths.to(dtype=real_dtype)
 
         def propagate_one(
             amplitude: torch.Tensor, wavelength: torch.Tensor
         ) -> torch.Tensor:
-            M1 = self._dft_matrix(v, y, wavelength, self.focal_length)
-            M2 = self._dft_matrix(x, u, wavelength, self.focal_length)
+            mx = self._dft_matrix(x, u, wavelength, self.focal_length)
+            my = self._dft_matrix(y, v, wavelength, self.focal_length)
             return (
-                (M2.T @ amplitude @ M1.T)
+                (my.T @ amplitude @ mx)
                 * field.grid.dx
                 * field.grid.dy
                 / (wavelength * self.focal_length)
             )
 
-        # field.amplitude : (n_wavelengths, nx, ny)
+        # field.complex_amplitude: (n_wavelengths, ny_in, nx_in)
+        # amplitude: (n_wavelengths, ny_out, nx_out)
         amplitude = torch.vmap(propagate_one)(field.complex_amplitude, wavelengths)
 
         return Field(amplitude, self.output_grid, field.spectrum)
@@ -56,26 +65,6 @@ class MFTPropagator(Propagator):
     @property
     def _symbol(self) -> str:
         return ">"
-
-    # def propagate(self, field: Field, output_grid: Grid) -> Field:
-    #     input_grid = field.grid
-    #     x, y = input_grid.x, input_grid.y
-    #     u, v = output_grid.x, output_grid.y
-
-    #     wavelengths = field.spectrum.wavelengths  # (n_wavelengths,)
-
-    #     def propagate_one(
-    #         amplitude: torch.Tensor, wavelength: torch.Tensor
-    #     ) -> torch.Tensor:
-    #         M1 = self._dft_matrix(v, y, wavelength, self.focal_length)
-    #         M2 = self._dft_matrix(x, u, wavelength, self.focal_length)
-    #         return M2.T @ amplitude @ M1.T
-
-    #     # field.amplitude : (n_wavelengths, nx, ny)
-    #     amplitude = torch.vmap(propagate_one)(field.complex_amplitude, wavelengths)
-
-    #     return Field(amplitude, output_grid, field.spectrum)
-
 
 @dataclass
 class IdentityPropagator(Propagator):

--- a/tests/test_rectangular_convention.py
+++ b/tests/test_rectangular_convention.py
@@ -1,0 +1,132 @@
+import pytest
+import torch
+
+from fiatlux.core.field import Field
+from fiatlux.core.grid import Grid
+from fiatlux.core.source import PlaneWave
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.detector import Detector
+from fiatlux.optics.elements.field_stop import ShanonFieldStop
+from fiatlux.optics.elements.mask import CircularAperture, TipTilt
+from fiatlux.optics.propagator import MFTPropagator
+from fiatlux.system.optical_system import SerialSystem
+
+
+def make_spectrum(samples=2, wavelength=1e-6):
+    return Spectrum(
+        magnitude=0,
+        band=Band(wavelength, 0.1e-6 if samples > 1 else 0.0, 1e8),
+        samples=samples,
+    )
+
+
+def test_grid_coordinates_follow_y_x_array_order():
+    grid = Grid(nx=7, ny=5, dx=0.2, dy=0.3)
+
+    x, y = grid.meshgrid()
+
+    assert grid.shape == (5, 7)
+    assert x.shape == y.shape == grid.shape
+    torch.testing.assert_close(x[0], grid.x)
+    torch.testing.assert_close(y[:, 0], grid.y)
+    assert torch.equal(x[0], x[-1])
+    assert torch.equal(y[:, 0], y[:, -1])
+
+
+def test_field_rejects_noncanonical_shapes():
+    grid = Grid(nx=7, ny=5, dx=0.2, dy=0.3)
+    spectrum = make_spectrum(samples=2)
+
+    with pytest.raises(ValueError, match="n_wavelengths, ny, nx"):
+        Field(torch.ones((2, 7, 5)), grid, spectrum)
+    with pytest.raises(ValueError, match="n_wavelengths, ny, nx"):
+        Field(torch.ones((5, 7)), grid, spectrum)
+
+
+def test_tip_and_tilt_vary_along_the_named_axes():
+    grid = Grid(nx=7, ny=5, dx=0.2, dy=0.3)
+    spectrum = make_spectrum(samples=1)
+    tip_only = TipTilt(grid, tip=1.0, tilt=0.0)
+    tilt_only = TipTilt(grid, tip=0.0, tilt=1.0)
+
+    tip_only.build(spectrum)
+    tilt_only.build(spectrum)
+
+    assert torch.all(torch.diff(tip_only.opd, dim=-1) > 0)
+    assert torch.all(torch.diff(tip_only.opd, dim=-2) == 0)
+    assert torch.all(torch.diff(tilt_only.opd, dim=-2) > 0)
+    assert torch.all(torch.diff(tilt_only.opd, dim=-1) == 0)
+
+
+def test_chromatic_field_stop_uses_lambda_y_x_order():
+    grid = Grid(nx=7, ny=5, dx=0.2, dy=0.3)
+    spectrum = make_spectrum(samples=2)
+    field_stop = ShanonFieldStop(grid)
+
+    field_stop.build(spectrum)
+
+    assert field_stop.transmission.shape == (2, 5, 7)
+    assert field_stop.opd.shape == (5, 7)
+
+
+def test_rectangular_mft_has_output_y_x_shape():
+    wavelength = 1e-6
+    focal_length = 2.0
+    input_grid = Grid(nx=8, ny=6, dx=0.1, dy=0.2)
+    output_grid = Grid(nx=10, ny=4, dx=1e-6, dy=2e-6)
+    field = PlaneWave(make_spectrum(samples=1, wavelength=wavelength)).generate_field(
+        input_grid
+    )
+
+    propagated = MFTPropagator(focal_length, output_grid).apply(field)
+
+    assert propagated.complex_amplitude.shape == (1, 4, 10)
+
+
+@pytest.mark.parametrize(
+    "tip_bin, tilt_bin",
+    [(1, 0), (0, 1)],
+)
+def test_mft_tip_tilt_shift_psf_along_the_expected_axis(tip_bin, tilt_bin):
+    nx, ny = 8, 6
+    dx, dy = 0.1, 0.2
+    wavelength = 1e-6
+    focal_length = 2.0
+    input_grid = Grid(nx=nx, ny=ny, dx=dx, dy=dy)
+    output_grid = Grid(
+        nx=nx,
+        ny=ny,
+        dx=wavelength * focal_length / (nx * dx),
+        dy=wavelength * focal_length / (ny * dy),
+    )
+    spectrum = make_spectrum(samples=1, wavelength=wavelength)
+    x, y = input_grid.meshgrid()
+    phase = 2 * torch.pi * (
+        tip_bin * x / (nx * dx) + tilt_bin * y / (ny * dy)
+    )
+    amplitude = torch.exp(1j * phase)[None]
+    field = Field(amplitude, input_grid, spectrum)
+
+    image = MFTPropagator(focal_length, output_grid).apply(field).intensity()[0]
+    peak_y, peak_x = torch.unravel_index(image.argmax(), image.shape)
+
+    assert peak_x.item() == nx // 2 + tip_bin
+    assert peak_y.item() == ny // 2 + tilt_bin
+
+
+def test_full_rectangular_simulation_reaches_detector():
+    wavelength = 1e-6
+    focal_length = 2.0
+    input_grid = Grid(nx=8, ny=6, dx=0.1, dy=0.2)
+    output_grid = Grid(nx=10, ny=4, dx=1e-6, dy=2e-6)
+    source = PlaneWave(make_spectrum(samples=2, wavelength=wavelength))
+    aperture = CircularAperture(input_grid, radius=0.4)
+    propagator = MFTPropagator(focal_length, output_grid)
+    detector = Detector(output_grid, exposure_time=1.0)
+    system = SerialSystem([aperture, propagator])
+
+    result = system.run(source, detector)
+
+    assert result.field_at(aperture).complex_amplitude.shape == (2, 6, 8)
+    assert result.field_at(propagator).complex_amplitude.shape == (2, 4, 10)
+    assert detector.image_buffer.shape == (4, 10)


### PR DESCRIPTION
## Convention canonique

Fiatlux utilise désormais explicitement :

```text
Field.complex_amplitude.shape = (n_wavelengths, ny, nx)
x = dernier axe
y = avant-dernier axe
Grid.shape = (ny, nx)
```

## Corrections principales

- validation immédiate de la dimension spectrale, de la forme spatiale et du device dans `Field` ;
- validation de `nx`, `ny`, `dx`, `dy` dans `Grid` et ajout de `Grid.shape` ;
- documentation explicite de la forme renvoyée par `Grid.meshgrid()` ;
- correction de la MFT en `My.T @ amplitude @ Mx`, avec matrices x et y séparées ;
- prise en charge d’entrées et sorties rectangulaires de dimensions différentes ;
- correction de l’orientation de `ProuhetThueMorse` ;
- réparation complète de `ShanonFieldStop`, auparavant incompatible avec l’API `Mask` et transposé ;
- validation des formes `(ny, nx)` ou `(n_lambda, ny, nx)` produites par les masques ;
- validation précoce des grilles pour masques, DM et détecteur ;
- suppression de l’ancienne implémentation MFT commentée utilisant la convention ambiguë.

## Validation géométrique

Les nouveaux tests vérifient :

- les coordonnées x sur le dernier axe et y sur l’avant-dernier ;
- le rejet des champs `(n_lambda, nx, ny)` ;
- l’orientation physique de tip et tilt ;
- une MFT `(6, 8) → (4, 10)` ;
- le déplacement de la PSF selon x pour un tip et selon y pour un tilt ;
- le field stop chromatique `(n_lambda, ny, nx)` ;
- une simulation rectangulaire complète source → ouverture → MFT → détecteur.

Un notebook visuel exécutable est inclus dans `examples/rectangular_grid_validation.ipynb`. Il affiche la pupille et la PSF rectangulaires, les déplacements indépendants par tip et tilt, ainsi que les trois plans du field stop chromatique.

```text
112 passed, 2 skipped
Notebook: all code cells executed successfully
```

Closes #1.
Closes #2.