### PR TITLE
Fix SquarePTTZonalBasis modal geometry

### DIFF
--- a/examples/square_ptt_basis_validation.ipynb
+++ b/examples/square_ptt_basis_validation.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Square piston-tip-tilt basis validation\n",
+    "\n",
+    "Visual inspection of the `SquarePTTZonalBasis` support, orientation and command ordering on a rectangular grid. Each modal value is dimensionless; DM commands supply the OPD scale in metres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "\n",
+    "from fiatlux import ActuatorGrid, DeformableMirror, Grid, SquarePTTZonalBasis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = Grid(nx=120, ny=80, dx=0.01, dy=0.01)\n",
+    "actuators = ActuatorGrid(n_actuators_x=2, n_actuators_y=2, pitch=0.5)\n",
+    "basis = SquarePTTZonalBasis(\n",
+    "    actuator_grid=actuators,\n",
+    "    pixel_grid=grid,\n",
+    "    influence_width=0.24,\n",
+    ")\n",
+    "matrix = basis.build_command_matrix()\n",
+    "n_actuators = actuators.n_actuators_x * actuators.n_actuators_y\n",
+    "modes = matrix.T.reshape(3, n_actuators, grid.ny, grid.nx)\n",
+    "\n",
+    "print('Command matrix:', tuple(matrix.shape))\n",
+    "print('Modes:', tuple(modes.shape), '= (piston/tip/tilt, actuator, ny, nx)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = ['Piston', 'Tip (x ramp)', 'Tilt (y ramp)']\n",
+    "fig, axes = plt.subplots(3, n_actuators, figsize=(12, 7), constrained_layout=True)\n",
+    "\n",
+    "for family in range(3):\n",
+    "    for actuator in range(n_actuators):\n",
+    "        image = modes[family, actuator]\n",
+    "        ax = axes[family, actuator]\n",
+    "        display = ax.imshow(\n",
+    "            image.cpu(),\n",
+    "            origin='lower',\n",
+    "            cmap='coolwarm',\n",
+    "            vmin=-1 if family else 0,\n",
+    "            vmax=1,\n",
+    "        )\n",
+    "        ax.set_title(f'{labels[family]} — actuator {actuator}')\n",
+    "        ax.set(xlabel='x pixel', ylabel='y pixel')\n",
+    "\n",
+    "fig.colorbar(display, ax=axes, shrink=0.8, label='Dimensionless modal value')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Expected visual result: piston is constant inside each square; tip is a horizontal ramp; tilt is a vertical ramp; every mode is exactly zero outside its actuator support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dm = DeformableMirror(\n",
+    "    grid=grid,\n",
+    "    actuator_grid=actuators,\n",
+    "    pixel_grid=grid,\n",
+    "    control_basis=basis,\n",
+    "    stroke=1e-6,\n",
+    ")\n",
+    "commands = torch.zeros(basis.n_modes)\n",
+    "commands[0] = 200e-9\n",
+    "commands[n_actuators + 1] = 300e-9\n",
+    "commands[2 * n_actuators + 2] = -250e-9\n",
+    "dm.commands = commands\n",
+    "\n",
+    "plt.figure(figsize=(7, 4))\n",
+    "plt.imshow(dm.opd.detach().cpu() * 1e9, origin='lower', cmap='coolwarm')\n",
+    "plt.colorbar(label='OPD (nm)')\n",
+    "plt.title(f'Combined rectangular DM OPD — shape {tuple(dm.opd.shape)}')\n",
+    "plt.xlabel('x pixel')\n",
+    "plt.ylabel('y pixel')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fiatlux/optics/elements/deformable_mirror.py
+++ b/fiatlux/optics/elements/deformable_mirror.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
+import math
 import torch
 from typing import Callable
 
@@ -20,6 +21,23 @@ class ActuatorGrid:
     n_actuators_x: int
     n_actuators_y: int
     pitch: float  # m between actuators
+
+    def positions(
+        self,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return x/y actuator positions centred on the optical axis."""
+        ax = (
+            torch.arange(self.n_actuators_x, device=device, dtype=dtype)
+            - (self.n_actuators_x - 1) / 2
+        ) * self.pitch
+        ay = (
+            torch.arange(self.n_actuators_y, device=device, dtype=dtype)
+            - (self.n_actuators_y - 1) / 2
+        ) * self.pitch
+        return ax, ay
 
 
 @dataclass
@@ -53,8 +71,7 @@ class GaussianZonalBasis(ControlBasis):
         y_flat = y.flatten()
 
         # Actuator positions in meters
-        ax = (torch.arange(ag.n_actuators_x) - ag.n_actuators_x // 2 + 1 / 2) * ag.pitch
-        ay = (torch.arange(ag.n_actuators_y) - ag.n_actuators_y // 2 + 1 / 2) * ag.pitch
+        ax, ay = ag.positions(device=pg.device, dtype=x.dtype)
         ax_grid, ay_grid = torch.meshgrid(ax, ay, indexing="xy")
         ax_flat = ax_grid.flatten()  # (n_actuators,)
         ay_flat = ay_grid.flatten()
@@ -96,8 +113,7 @@ class SquareZonalBasis(ControlBasis):
         y_flat = y.flatten()
 
         # Actuator positions in meters
-        ax = (torch.arange(ag.n_actuators_x) - ag.n_actuators_x // 2 + 1 / 2) * ag.pitch
-        ay = (torch.arange(ag.n_actuators_y) - ag.n_actuators_y // 2 + 1 / 2) * ag.pitch
+        ax, ay = ag.positions(device=pg.device, dtype=x.dtype)
         ax_grid, ay_grid = torch.meshgrid(ax, ay, indexing="xy")
         ax_flat = ax_grid.flatten()  # (n_actuators,)
         ay_flat = ay_grid.flatten()
@@ -126,10 +142,15 @@ class SquarePTTZonalBasis(ControlBasis):
     pixel_grid: Grid
     influence_width: float
 
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.influence_width) or self.influence_width <= 0:
+            raise ValueError("influence_width must be a positive finite length.")
+
     def build_command_matrix(self):
-        """
-        Gaussian influence function for each actuator onto the pixel grid.
-        Shape : (nx*ny, n_actuators)
+        """Build dimensionless piston/tip/tilt modes on square supports.
+
+        Columns are ordered as all piston modes, then all x-tip modes, then all
+        y-tilt modes. The matrix shape is ``(ny * nx, 3 * n_actuators)``.
         """
         ag = self.actuator_grid
         pg = self.pixel_grid
@@ -138,8 +159,7 @@ class SquarePTTZonalBasis(ControlBasis):
         y_flat = y.flatten()
 
         # Actuator positions in meters
-        ax = (torch.arange(ag.n_actuators_x) - ag.n_actuators_x // 2 + 1 / 2) * ag.pitch
-        ay = (torch.arange(ag.n_actuators_y) - ag.n_actuators_y // 2 + 1 / 2) * ag.pitch
+        ax, ay = ag.positions(device=pg.device, dtype=x.dtype)
         ax_grid, ay_grid = torch.meshgrid(ax, ay, indexing="xy")
         ax_flat = ax_grid.flatten()  # (n_actuators,)
         ay_flat = ay_grid.flatten()
@@ -148,23 +168,12 @@ class SquarePTTZonalBasis(ControlBasis):
         dx = x_flat[:, None] - ax_flat[None, :]
         dy = y_flat[:, None] - ay_flat[None, :]
 
-        piston = torch.zeros(dx.shape)
-        piston[
-            (torch.abs(dx) < self.influence_width)
-            & (torch.abs(dy) < self.influence_width)
-        ] = 1
-
-        tip = dx
-        tip[
-            (torch.abs(dx) < self.influence_width)
-            & (torch.abs(dy) < self.influence_width)
-        ] = 1
-
-        tilt = dy
-        tilt[
-            (torch.abs(dx) < self.influence_width)
-            & (torch.abs(dy) < self.influence_width)
-        ] = 1
+        support = (torch.abs(dx) < self.influence_width) & (
+            torch.abs(dy) < self.influence_width
+        )
+        piston = support.to(dx.dtype)
+        tip = torch.where(support, dx / self.influence_width, 0.0)
+        tilt = torch.where(support, dy / self.influence_width, 0.0)
 
         influence = torch.cat([piston, tip, tilt], dim=1)
 

--- a/tests/test_square_ptt_basis.py
+++ b/tests/test_square_ptt_basis.py
@@ -1,0 +1,80 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.optics.elements.deformable_mirror import (
+    ActuatorGrid,
+    DeformableMirror,
+    SquarePTTZonalBasis,
+)
+
+
+def split_single_actuator_modes(basis: SquarePTTZonalBasis):
+    matrix = basis.build_command_matrix()
+    return tuple(matrix[:, index].reshape(basis.pixel_grid.shape) for index in range(3))
+
+
+@pytest.mark.parametrize(
+    "grid",
+    [
+        Grid(nx=9, ny=9, dx=0.25, dy=0.25),
+        Grid(nx=9, ny=7, dx=0.25, dy=0.5),
+    ],
+)
+def test_single_actuator_ptt_modes_have_expected_support_and_values(grid):
+    width = 0.8
+    basis = SquarePTTZonalBasis(
+        actuator_grid=ActuatorGrid(1, 1, pitch=1.0),
+        pixel_grid=grid,
+        influence_width=width,
+    )
+    piston, tip, tilt = split_single_actuator_modes(basis)
+    x, y = grid.meshgrid()
+    support = (x.abs() < width) & (y.abs() < width)
+
+    torch.testing.assert_close(piston, support.to(piston.dtype))
+    torch.testing.assert_close(tip[support], x[support] / width)
+    torch.testing.assert_close(tilt[support], y[support] / width)
+    assert torch.count_nonzero(tip[~support]) == 0
+    assert torch.count_nonzero(tilt[~support]) == 0
+
+
+def test_tip_varies_only_along_x_and_tilt_only_along_y():
+    grid = Grid(nx=7, ny=5, dx=0.1, dy=0.1)
+    basis = SquarePTTZonalBasis(ActuatorGrid(1, 1, 1.0), grid, 1.0)
+    _, tip, tilt = split_single_actuator_modes(basis)
+
+    assert torch.all(torch.diff(tip, dim=-1) > 0)
+    assert torch.all(torch.diff(tip, dim=-2) == 0)
+    assert torch.all(torch.diff(tilt, dim=-2) > 0)
+    assert torch.all(torch.diff(tilt, dim=-1) == 0)
+
+
+@pytest.mark.parametrize("n_x,n_y", [(1, 1), (2, 4), (3, 5)])
+def test_actuator_positions_are_symmetric_about_zero(n_x, n_y):
+    actuator_grid = ActuatorGrid(n_x, n_y, pitch=0.5)
+
+    x, y = actuator_grid.positions(device=torch.device("cpu"), dtype=torch.float32)
+
+    torch.testing.assert_close(x, -x.flip(0))
+    torch.testing.assert_close(y, -y.flip(0))
+
+
+def test_ptt_command_matrix_and_dm_opd_use_rectangular_y_x_shape():
+    grid = Grid(nx=9, ny=7, dx=0.25, dy=0.5)
+    actuator_grid = ActuatorGrid(1, 1, pitch=1.0)
+    basis = SquarePTTZonalBasis(actuator_grid, grid, influence_width=0.8)
+    dm = DeformableMirror(grid, actuator_grid, grid, basis)
+
+    assert dm._command_matrix.shape == (grid.ny * grid.nx, 3)
+    assert dm.opd.shape == (grid.ny, grid.nx)
+
+
+@pytest.mark.parametrize("width", [0.0, -1.0, float("inf"), float("nan")])
+def test_ptt_basis_rejects_invalid_influence_width(width):
+    with pytest.raises(ValueError, match="positive finite length"):
+        SquarePTTZonalBasis(
+            ActuatorGrid(1, 1, 1.0),
+            Grid(nx=3, ny=3, dx=0.1, dy=0.1),
+            width,
+        )


### PR DESCRIPTION
## Corrections

- centre correctement les positions d’actionneurs pairs et impairs autour de zéro ;
- centralise ce calcul dans `ActuatorGrid.positions()` pour les bases Gaussian, Square et SquarePTT ;
- construit le piston comme une constante unitaire dans le support ;
- construit le tip comme une rampe x normalisée `dx / influence_width` ;
- construit le tilt comme une rampe y normalisée `dy / influence_width` ;
- force les trois familles de modes à zéro hors du support ;
- conserve des modes sans dimension, afin que les commandes du DM restent des coefficients d’OPD en mètres ;
- valide `influence_width` ;
- confirme `dm.opd.shape == (ny, nx)` sur grille rectangulaire.

Les colonnes restent ordonnées ainsi :

```text
[pistons de tous les actionneurs, tips de tous les actionneurs, tilts de tous les actionneurs]
```

## Validation

```text
123 passed, 2 skipped
```

Les tests vérifient analytiquement support, valeurs, orientation, symétrie des positions et forme de l’OPD sur grilles carrées et rectangulaires.

Le notebook `examples/square_ptt_basis_validation.ipynb` affiche les 12 modes d’une base PTT 2×2 sur une grille 80×120 ainsi qu’une OPD combinée. Toutes ses cellules ont été exécutées avec succès.

Closes #11.