### PR TITLE
Make device and dtype handling consistent

### DIFF
--- a/fiatlux/core/field.py
+++ b/fiatlux/core/field.py
@@ -75,17 +75,30 @@ class Field:
     # def is_frequency(self) -> bool:
     #     return isinstance(self.grid, FrequencyGrid)
 
-    def to(self, device: torch.device | str) -> Field:
-        """Return a new field with all tensor state moved to ``device``.
+    def to(
+        self,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> Field:
+        """Return a new field with coherent device and dtype state.
 
-        The complex-amplitude, wavelength and flux dtypes are preserved.
-        Neither this field nor its associated grid and spectrum are mutated.
+        A requested complex dtype is mapped to its corresponding real dtype
+        for coordinates, wavelengths and fluxes. Neither the source field nor
+        its associated grid and spectrum are mutated.
         """
-        device = torch.device(device)
+        amplitude_dtype = self.complex_amplitude.dtype if dtype is None else dtype
+        if amplitude_dtype in (torch.complex64, torch.float32):
+            real_dtype = torch.float32
+        elif amplitude_dtype in (torch.complex128, torch.float64):
+            real_dtype = torch.float64
+        else:
+            raise ValueError(
+                "Field dtype must be float32, float64, complex64 or complex128."
+            )
         return Field(
-            self.complex_amplitude.to(device),
-            self.grid.to(device),
-            self.spectrum.to(device),
+            self.complex_amplitude.to(device=device, dtype=amplitude_dtype),
+            self.grid.to(device=device, dtype=real_dtype),
+            self.spectrum.to(device=device, dtype=real_dtype),
         )
 
     def _validate_compatible_field(self, other: Field) -> None:

--- a/fiatlux/core/grid.py
+++ b/fiatlux/core/grid.py
@@ -12,7 +12,11 @@ class BaseGrid(ABC):
     def meshgrid(self) -> tuple[torch.Tensor, torch.Tensor]: ...
 
     @abstractmethod
-    def to(self, device: torch.device) -> BaseGrid: ...
+    def to(
+        self,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> BaseGrid: ...
 
 
 @dataclass
@@ -22,6 +26,7 @@ class Grid(BaseGrid):
     dx: float
     dy: float
     device: torch.device = torch.device("cpu")
+    dtype: torch.dtype = torch.float32
 
     def __post_init__(self) -> None:
         for name in ("nx", "ny"):
@@ -33,6 +38,8 @@ class Grid(BaseGrid):
             if not math.isfinite(value) or value <= 0:
                 raise ValueError(f"{name} must be a positive finite spacing.")
         self.device = torch.device(self.device)
+        if self.dtype not in (torch.float32, torch.float64):
+            raise ValueError("Grid dtype must be torch.float32 or torch.float64.")
 
     @property
     def shape(self) -> tuple[int, int]:
@@ -41,15 +48,30 @@ class Grid(BaseGrid):
 
     @property
     def x(self) -> torch.Tensor:
-        return (torch.arange(self.nx, device=self.device) - self.nx // 2) * self.dx
+        return (
+            torch.arange(self.nx, device=self.device, dtype=self.dtype) - self.nx // 2
+        ) * self.dx
 
     @property
     def y(self) -> torch.Tensor:
-        return (torch.arange(self.ny, device=self.device) - self.ny // 2) * self.dy
+        return (
+            torch.arange(self.ny, device=self.device, dtype=self.dtype) - self.ny // 2
+        ) * self.dy
 
     def meshgrid(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Return ``(x, y)`` coordinate arrays, both shaped ``(ny, nx)``."""
         return torch.meshgrid(self.x, self.y, indexing="xy")
 
-    def to(self, device: torch.device) -> Grid:
-        return Grid(self.nx, self.ny, self.dx, self.dy, device)
+    def to(
+        self,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> Grid:
+        return Grid(
+            self.nx,
+            self.ny,
+            self.dx,
+            self.dy,
+            self.device if device is None else torch.device(device),
+            self.dtype if dtype is None else dtype,
+        )

--- a/fiatlux/core/source.py
+++ b/fiatlux/core/source.py
@@ -65,10 +65,13 @@ class PlaneWave(Source):
         super().__init__(spectrum)
 
     def generate_field(self, grid: Grid) -> Field:
-        spectrum = self.spectrum.to(grid.device)
+        spectrum = self.spectrum.to(device=grid.device, dtype=grid.dtype)
+        complex_dtype = (
+            torch.complex64 if grid.dtype == torch.float32 else torch.complex128
+        )
         spatial_amplitude = torch.ones(
             (grid.ny, grid.nx),
-            dtype=torch.complex64,
+            dtype=complex_dtype,
             device=grid.device,
         )
         return Field(
@@ -96,10 +99,13 @@ class GaussianSource(Source):
 
     def generate_field(self, grid: Grid) -> Field:
         x, y = grid.meshgrid()
-        spectrum = self.spectrum.to(grid.device)
+        spectrum = self.spectrum.to(device=grid.device, dtype=grid.dtype)
+        complex_dtype = (
+            torch.complex64 if grid.dtype == torch.float32 else torch.complex128
+        )
         spatial_amplitude = torch.exp(
             -(x**2 + y**2) / self.waist**2
-        ).to(torch.complex64)
+        ).to(complex_dtype)
         amplitude = self._normalize_spatial_amplitude(
             spatial_amplitude,
             grid,

--- a/fiatlux/core/spectrum.py
+++ b/fiatlux/core/spectrum.py
@@ -67,34 +67,86 @@ class PhotometricBand:
 
 
 class Spectrum:
-    def __init__(self, magnitude: float, band: Band, samples: int):
+    def __init__(
+        self,
+        magnitude: float,
+        band: Band,
+        samples: int,
+        *,
+        device: torch.device | str = "cpu",
+        dtype: torch.dtype = torch.float32,
+    ):
         if not isinstance(samples, int) or isinstance(samples, bool) or samples < 1:
             raise ValueError("samples must be a positive integer.")
 
+        if dtype not in (torch.float32, torch.float64):
+            raise ValueError("Spectrum dtype must be torch.float32 or torch.float64.")
         self.magnitude = magnitude
-        self._set_wavelengths(band, samples)
-        self._set_fluxes(self.magnitude, band, samples)
-
-    def _set_wavelengths(self, band: Band, samples: int):
-        if samples == 1:
-            self.wavelengths = torch.tensor([band.central_wavelength])
-            return
-        self.wavelengths = band.central_wavelength + band.delta_wavelength * (
-            torch.linspace(0, 1, samples) - 0.5
+        self._set_wavelengths(band, samples, device=torch.device(device), dtype=dtype)
+        self._set_fluxes(
+            self.magnitude,
+            band,
+            samples,
+            device=torch.device(device),
+            dtype=dtype,
         )
 
-    def _set_fluxes(self, magnitude: float, band: Band, samples: int):
-        self.fluxes = band.photon_flux(magnitude) * torch.ones(samples) / samples
+    def _set_wavelengths(
+        self,
+        band: Band,
+        samples: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ):
+        if samples == 1:
+            self.wavelengths = torch.tensor(
+                [band.central_wavelength], device=device, dtype=dtype
+            )
+            return
+        self.wavelengths = band.central_wavelength + band.delta_wavelength * (
+            torch.linspace(0, 1, samples, device=device, dtype=dtype) - 0.5
+        )
 
-    def to(self, device: torch.device | str) -> Spectrum:
-        """Return a new spectrum object whose tensors are on ``device``."""
+    def _set_fluxes(
+        self,
+        magnitude: float,
+        band: Band,
+        samples: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ):
+        self.fluxes = torch.full(
+            (samples,),
+            band.photon_flux(magnitude) / samples,
+            device=device,
+            dtype=dtype,
+        )
+
+    def to(
+        self,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> Spectrum:
+        """Return a new spectrum with the requested device and real dtype."""
+        if dtype is not None and dtype not in (torch.float32, torch.float64):
+            raise ValueError("Spectrum dtype must be torch.float32 or torch.float64.")
         moved = copy(self)
-        moved.wavelengths = self.wavelengths.to(device)
-        moved.fluxes = self.fluxes.to(device)
+        moved.wavelengths = self.wavelengths.to(device=device, dtype=dtype)
+        moved.fluxes = self.fluxes.to(device=device, dtype=dtype)
         return moved
 
     @classmethod
-    def from_sampling(cls, magnitude: float, band: Band, Nu: int) -> Spectrum:
+    def from_sampling(
+        cls,
+        magnitude: float,
+        band: Band,
+        Nu: int,
+        *,
+        device: torch.device | str = "cpu",
+        dtype: torch.dtype = torch.float32,
+    ) -> Spectrum:
         """Build a spectrum sampled at approximately one focal-plane pixel.
 
         At least one channel is always returned. Monochromatic bands and bands
@@ -108,10 +160,17 @@ class Spectrum:
         d_lambda = 2 * lambda_max / Nu
         n_lambda = max(1, round(band.delta_wavelength / d_lambda))
 
-        spectrum = cls(magnitude=magnitude, band=band, samples=n_lambda)
+        spectrum = cls(
+            magnitude=magnitude,
+            band=band,
+            samples=n_lambda,
+            device=device,
+            dtype=dtype,
+        )
         if n_lambda > 1:
             spectrum.wavelengths = torch.sort(
-                lambda_max - torch.arange(n_lambda) * d_lambda
+                lambda_max
+                - torch.arange(n_lambda, device=device, dtype=dtype) * d_lambda
             ).values
 
         return spectrum

--- a/fiatlux/optics/adc.py
+++ b/fiatlux/optics/adc.py
@@ -84,7 +84,9 @@ class ADCDispersionModel:
         )
 
         return torch.deg2rad(
-            torch.tan(torch.deg2rad(torch.as_tensor(angle)))
+            torch.tan(
+                torch.deg2rad(torch.as_tensor(angle, device=wl.device, dtype=wl.dtype))
+            )
             * (N0_1 - N_1)
             * 206264.8
             / 3600

--- a/fiatlux/optics/atmosphere.py
+++ b/fiatlux/optics/atmosphere.py
@@ -35,7 +35,7 @@ class AtmosphereModel(ABC):
         *,
         reference_wavelength: float,
         seed: int | None = None,
-        dtype: torch.dtype = torch.float32,
+        dtype: torch.dtype | None = None,
     ) -> None:
         if grid.nx < 2 or grid.ny < 2:
             raise ValueError("Atmospheric grids require nx >= 2 and ny >= 2.")
@@ -43,6 +43,7 @@ class AtmosphereModel(ABC):
             raise ValueError("Atmospheric grid spacings dx and dy must be positive.")
         if reference_wavelength <= 0:
             raise ValueError("reference_wavelength must be positive.")
+        dtype = grid.dtype if dtype is None else dtype
         if dtype not in (torch.float32, torch.float64):
             raise TypeError("dtype must be torch.float32 or torch.float64.")
 
@@ -165,7 +166,7 @@ class KolmogorovAtmosphereModel(AtmosphereModel):
         *,
         outer_scale: float | None = None,
         seed: int | None = None,
-        dtype: torch.dtype = torch.float32,
+        dtype: torch.dtype | None = None,
     ) -> None:
         if r0 <= 0:
             raise ValueError("r0 must be positive.")
@@ -235,7 +236,7 @@ class NCPAModel:
         spectral_index: float = 3.0,
         outer_scale: float | None = None,
         seed: int | None = None,
-        dtype: torch.dtype = torch.float32,
+        dtype: torch.dtype | None = None,
     ) -> None:
         if grid.nx < 2 or grid.ny < 2:
             raise ValueError("NCPA grids require nx >= 2 and ny >= 2.")
@@ -247,6 +248,7 @@ class NCPAModel:
             raise ValueError("spectral_index must be positive.")
         if outer_scale is not None and outer_scale <= 0:
             raise ValueError("outer_scale must be positive or None.")
+        dtype = grid.dtype if dtype is None else dtype
         if dtype not in (torch.float32, torch.float64):
             raise TypeError("dtype must be torch.float32 or torch.float64.")
 

--- a/fiatlux/optics/detector.py
+++ b/fiatlux/optics/detector.py
@@ -45,7 +45,7 @@ class Detector:
         self.digitize = digitize
         self.sensitivity = sensitivity
         self.random_seed = random_seed
-        self.generator = torch.Generator().manual_seed(random_seed)
+        self.generator = torch.Generator(device=grid.device).manual_seed(random_seed)
         self.name = name
         self.image_buffer = None
 
@@ -88,15 +88,12 @@ class Detector:
 
     def add_readout_noise(self, electrons: torch.Tensor):
         """Add zero-mean Gaussian read noise with variance in electrons²."""
-        return (
-            torch.normal(
-                mean=0,
-                std=self.readout_noise_variance**0.5,
-                size=electrons.shape,
-                generator=self.generator,
-            )
-            + electrons
+        noise = torch.normal(
+            mean=torch.zeros_like(electrons),
+            std=self.readout_noise_variance**0.5,
+            generator=self.generator,
         )
+        return electrons + noise
 
     def photons_to_electrons(self, photons: torch.Tensor):
         return self.quantum_efficiency * photons

--- a/fiatlux/optics/elements/deformable_mirror.py
+++ b/fiatlux/optics/elements/deformable_mirror.py
@@ -122,7 +122,12 @@ class SquareZonalBasis(ControlBasis):
         dx = x_flat[:, None] - ax_flat[None, :]
         dy = y_flat[:, None] - ay_flat[None, :]
 
-        influence = torch.zeros(self.pixel_grid.ny * self.pixel_grid.nx, self.n_modes)
+        influence = torch.zeros(
+            self.pixel_grid.ny * self.pixel_grid.nx,
+            self.n_modes,
+            device=pg.device,
+            dtype=pg.dtype,
+        )
         influence[
             (torch.abs(dx) < self.influence_width)
             & (torch.abs(dy) < self.influence_width)
@@ -192,14 +197,17 @@ class FourierBasis(ControlBasis):
     pupil: Mask
 
     def build_command_matrix(self):
-        n_freqs = len(self.frequencies)
+        frequencies = self.frequencies.to(
+            device=self.pixel_grid.device, dtype=self.pixel_grid.dtype
+        )
+        n_freqs = len(frequencies)
 
         # Pixel coordinate grids  (resolution, resolution)
         x, y = self.pixel_grid.meshgrid()  # (ny, nx)
 
         # All (freq_x, freq_y) pairs  →  (n_freqs, n_freqs)
-        freq_x = self.frequencies[:, None].expand(n_freqs, n_freqs)
-        freq_y = self.frequencies[None, :].expand(n_freqs, n_freqs)
+        freq_x = frequencies[:, None].expand(n_freqs, n_freqs)
+        freq_y = frequencies[None, :].expand(n_freqs, n_freqs)
 
         # Phase for every pair and every pixel  →  (n_freqs, n_freqs, resolution, resolution)
         phase = (
@@ -208,7 +216,9 @@ class FourierBasis(ControlBasis):
 
         # Cosine for freq_x < 0, or freq_x == 0 and freq_y <= 0 (avoids cos/sin redundancy)
         # use_cosine = (freq_x < 0) | ((freq_x <= 0) & (freq_y >= 0))
-        use_cosine = torch.full((n_freqs, n_freqs), True)
+        use_cosine = torch.full(
+            (n_freqs, n_freqs), True, device=self.pixel_grid.device
+        )
         center_freq = n_freqs**2 / 2
         use_cosine[: int(center_freq // n_freqs), :] = False
         use_cosine[int(center_freq // n_freqs), : int(center_freq % n_freqs)] = False
@@ -281,7 +291,7 @@ class ZernikeBasis(ControlBasis):
         modes = zernike_basis(
             nterms=self.n + 1,
             npix=self.pixel_grid.nx,
-        )
+        ).to(device=self.pixel_grid.device, dtype=self.pixel_grid.dtype)
 
         return modes[1:, ...].flatten(1, -1).T
 
@@ -326,23 +336,27 @@ class DeformableMirror(torch.nn.Module):
             torch.zeros(
                 self.control_basis.n_modes,
                 device=self.pixel_grid.device,
+                dtype=self.pixel_grid.dtype,
             )
         )
 
         # Precompute influence matrix (actuators → pixels) — fixed geometry
         self.register_buffer(
             "_command_matrix",
-            self.control_basis.build_command_matrix().to(self.pixel_grid.device),
+            self.control_basis.build_command_matrix().to(
+                device=self.pixel_grid.device, dtype=self.pixel_grid.dtype
+            ),
         )
 
     def _apply(self, fn, recurse=True):
         """Apply PyTorch transfers and keep grid device metadata consistent."""
         super()._apply(fn, recurse=recurse)
         device = self._commands.device
-        self.grid = self.grid.to(device)
-        self.pixel_grid = self.pixel_grid.to(device)
+        dtype = self._commands.dtype
+        self.grid = self.grid.to(device, dtype)
+        self.pixel_grid = self.pixel_grid.to(device, dtype)
         if hasattr(self.control_basis, "pixel_grid"):
-            self.control_basis.pixel_grid = self.control_basis.pixel_grid.to(device)
+            self.control_basis.pixel_grid = self.control_basis.pixel_grid.to(device, dtype)
         return self
 
     @property

--- a/fiatlux/optics/elements/field_stop.py
+++ b/fiatlux/optics/elements/field_stop.py
@@ -37,7 +37,7 @@ class ShanonFieldStop(Mask):
                 (
                     (x.abs() <= x_limit * (wl / lambda_max))
                     & (y.abs() <= y_limit * (wl / lambda_max))
-                ).to(torch.complex64)
+                ).to(self.grid.dtype)
                 for wl in self._spectrum.wavelengths
             ],
             dim=0,
@@ -47,4 +47,5 @@ class ShanonFieldStop(Mask):
         self.opd = torch.zeros(
             self.grid.shape,
             device=self.grid.device,
+            dtype=self.grid.dtype,
         )

--- a/fiatlux/optics/elements/mask.py
+++ b/fiatlux/optics/elements/mask.py
@@ -99,7 +99,7 @@ class CircularAperture(Mask):
         self.transmission = r <= self.radius
 
     def _build_opd(self) -> None:
-        self.opd = torch.zeros((self.grid.ny, self.grid.nx))
+        self.opd = torch.zeros(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     @property
     def _symbol(self) -> str:
@@ -121,10 +121,10 @@ class ArbitraryAperture(Mask):
             )
 
         # Use provided tensor
-        self.transmission = self._input_transmission
+        self.transmission = self._input_transmission.to(device=self.grid.device)
 
     def _build_opd(self) -> None:
-        self.opd = torch.zeros((self.grid.ny, self.grid.nx))
+        self.opd = torch.zeros(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     @property
     def _symbol(self) -> str:
@@ -139,7 +139,7 @@ class ZeldaMask(Mask):
         super().__init__(grid=grid)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
         x, y = self.grid.meshgrid()
@@ -160,7 +160,7 @@ class ZeldaStop(Mask):
         self.transmission = r <= self.radius
 
     def _build_opd(self) -> None:
-        self.opd = torch.zeros((self.grid.ny, self.grid.nx))
+        self.opd = torch.zeros(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
 
 @register_type("Piston")
@@ -171,10 +171,10 @@ class Piston(Mask):
         super().__init__(grid=grid)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
-        self.opd = self.piston * torch.ones((self.grid.ny, self.grid.nx))
+        self.opd = self.piston * torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
 
 @register_type("Step")
@@ -185,12 +185,12 @@ class Step(Mask):
         super().__init__(grid=grid)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
-        tmp = torch.ones((self.grid.ny, self.grid.nx))
+        tmp = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
         tmp[:, : self.grid.nx // 2] = 0
-        self.opd = self.piston * (torch.ones((self.grid.ny, self.grid.nx)) - tmp)
+        self.opd = self.piston * (torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype) - tmp)
 
 
 @register_type("TipTilt")
@@ -202,7 +202,7 @@ class TipTilt(Mask):
         super().__init__(grid=grid)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
         x, y = self.grid.meshgrid()
@@ -224,40 +224,42 @@ class ProuhetThueMorse(Mask):
         return p
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
         y, x = torch.meshgrid(
-            torch.arange(self.grid.ny),
-            torch.arange(self.grid.nx),
+            torch.arange(self.grid.ny, device=self.grid.device),
+            torch.arange(self.grid.nx, device=self.grid.device),
             indexing="ij",
         )
 
         # XOR-based 2D PTM
         Z = x ^ y
 
-        self.opd = 600e-9 * self.parity_popcount(Z).float()
+        self.opd = 600e-9 * self.parity_popcount(Z).to(self.grid.dtype)
 
 
 @register_type("ADC")
 class ADC(Mask):
 
     def __init__(
-        self, grid: Grid, amplitude: torch.Tensor, angle: float = torch.tensor(0.0)
+        self, grid: Grid, amplitude: torch.Tensor, angle: float = 0.0
     ):
         self.amplitude = amplitude
         self.angle = angle
         super().__init__(grid=grid)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
         x, y = self.grid.meshgrid()
 
-        self.opd = self.amplitude[:, None, None] * (
-            x * torch.cos(torch.deg2rad(torch.as_tensor(self.angle)))
-            + y * torch.sin(torch.deg2rad(torch.as_tensor(self.angle)))
+        amplitude = self.amplitude.to(device=self.grid.device, dtype=self.grid.dtype)
+        angle = torch.as_tensor(self.angle, device=self.grid.device, dtype=self.grid.dtype)
+        self.opd = amplitude[:, None, None] * (
+            x * torch.cos(torch.deg2rad(angle))
+            + y * torch.sin(torch.deg2rad(angle))
         )
 
 
@@ -318,10 +320,10 @@ class Random(Mask):
         super().__init__(grid=grid, recompute=recompute)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
-        self.opd = self.amplitude * torch.randn((self.grid.ny, self.grid.nx))
+        self.opd = self.amplitude * torch.randn(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
 
 class HarmoniResiduals(Mask):
@@ -357,7 +359,7 @@ class HarmoniResiduals(Mask):
         self.datacube = torch.cat(datacube, dim=0)
 
     def _build_transmission(self) -> None:
-        self.transmission = torch.ones((self.grid.ny, self.grid.nx))
+        self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
-        self.opd = self.datacube[next(self.iterator), ...]
+        self.opd = self.datacube[next(self.iterator), ...].to(device=self.grid.device, dtype=self.grid.dtype)

--- a/fiatlux/optics/propagator.py
+++ b/fiatlux/optics/propagator.py
@@ -33,6 +33,8 @@ class MFTPropagator(Propagator):
     def apply(self, field: Field) -> Field:
         if field.grid.device != self.output_grid.device:
             raise ValueError("MFT input and output grids must be on the same device.")
+        if field.grid.dtype != self.output_grid.dtype:
+            raise ValueError("MFT input and output grids must have the same dtype.")
 
         x, y = field.grid.x, field.grid.y
         u, v = self.output_grid.x, self.output_grid.y

--- a/tests/test_device_dtype.py
+++ b/tests/test_device_dtype.py
@@ -1,0 +1,108 @@
+import pytest
+import torch
+
+from fiatlux.core.field import Field
+from fiatlux.core.grid import Grid
+from fiatlux.core.source import PlaneWave
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.detector import Detector
+from fiatlux.optics.elements.deformable_mirror import (
+    ActuatorGrid,
+    DeformableMirror,
+    SquareZonalBasis,
+)
+from fiatlux.optics.elements.mask import CircularAperture, TipTilt
+from fiatlux.optics.propagator import MFTPropagator
+
+
+def make_spectrum(device="cpu", dtype=torch.float32, samples=2):
+    return Spectrum(
+        magnitude=0,
+        band=Band(1.0e-6, 0.1e-6, 1.0e8),
+        samples=samples,
+        device=device,
+        dtype=dtype,
+    )
+
+
+def run_system(device, real_dtype, samples=2):
+    pupil_grid = Grid(8, 6, 0.1, 0.12, device=device, dtype=real_dtype)
+    image_grid = Grid(10, 4, 1.0e-6, 1.5e-6, device=device, dtype=real_dtype)
+    spectrum = make_spectrum(device, real_dtype, samples=samples)
+    field = PlaneWave(spectrum).generate_field(pupil_grid)
+    field = CircularAperture(pupil_grid, radius=0.31).apply(field)
+    field = TipTilt(pupil_grid, tip=1.0e-8, tilt=-2.0e-8).apply(field)
+    field = MFTPropagator(2.0, image_grid).apply(field)
+    image = Detector(image_grid, exposure_time=1.0).acquire(field)
+    return field, image
+
+
+@pytest.mark.parametrize(
+    "real_dtype,complex_dtype",
+    [(torch.float32, torch.complex64), (torch.float64, torch.complex128)],
+)
+def test_representative_system_preserves_device_and_precision(
+    real_dtype, complex_dtype
+):
+    field, image = run_system("cpu", real_dtype)
+
+    assert field.grid.dtype == real_dtype
+    assert field.spectrum.wavelengths.dtype == real_dtype
+    assert field.spectrum.fluxes.dtype == real_dtype
+    assert field.complex_amplitude.dtype == complex_dtype
+    assert image.dtype == real_dtype
+    assert field.complex_amplitude.device.type == "cpu"
+    assert image.device.type == "cpu"
+
+
+def test_float32_and_float64_systems_agree_numerically():
+    _, image32 = run_system("cpu", torch.float32, samples=1)
+    _, image64 = run_system("cpu", torch.float64, samples=1)
+
+    torch.testing.assert_close(image32.double(), image64, rtol=2e-5, atol=1e-8)
+
+
+def test_field_to_transfers_all_associated_state():
+    grid = Grid(5, 3, 0.1, 0.2)
+    field = PlaneWave(make_spectrum()).generate_field(grid)
+
+    moved = field.to(dtype=torch.complex128)
+
+    assert moved.complex_amplitude.dtype == torch.complex128
+    assert moved.grid.dtype == torch.float64
+    assert moved.spectrum.wavelengths.dtype == torch.float64
+    assert moved.spectrum.fluxes.dtype == torch.float64
+
+
+def test_deformable_mirror_uses_grid_device_and_dtype():
+    grid = Grid(7, 5, 0.1, 0.1, dtype=torch.float64)
+    actuators = ActuatorGrid(2, 2, 0.2)
+    basis = SquareZonalBasis(actuators, grid, influence_width=0.11)
+    dm = DeformableMirror(grid, actuators, grid, basis)
+
+    assert dm.commands.dtype == torch.float64
+    assert dm.commands.device == grid.device
+    assert dm._command_matrix.dtype == torch.float64
+    assert dm._command_matrix.device == grid.device
+    assert dm.opd.dtype == torch.float64
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cpu_and_cuda_systems_agree():
+    _, cpu_image = run_system("cpu", torch.float64)
+    cuda_field, cuda_image = run_system("cuda", torch.float64)
+
+    assert cuda_field.complex_amplitude.device.type == "cuda"
+    assert cuda_image.device.type == "cuda"
+    torch.testing.assert_close(cuda_image.cpu(), cpu_image, rtol=1e-10, atol=1e-10)
+
+
+def test_field_rejects_unsupported_transfer_dtype():
+    field = Field(
+        torch.ones((2, 3, 5), dtype=torch.complex64),
+        Grid(5, 3, 0.1, 0.2),
+        make_spectrum(),
+    )
+
+    with pytest.raises(ValueError, match="Field dtype"):
+        field.to(dtype=torch.float16)


### PR DESCRIPTION
## Summary

- make `Grid` own both a real dtype and a device, with `float32`/`float64` validation
- let `Spectrum.to()` and `Field.to()` transfer device and precision coherently
- generate source fields as `complex64` or `complex128` from the grid precision
- create mask, atmosphere, ADC, detector-noise and deformable-mirror tensors on the correct device and dtype
- reject MFT propagation between grids with inconsistent precision
- add representative CPU precision tests and a conditional CPU/CUDA parity test

## Tensor contract

| State | float32 pipeline | float64 pipeline |
|---|---:|---:|
| grids, wavelengths, fluxes, OPD, detector image | `torch.float32` | `torch.float64` |
| optical field | `torch.complex64` | `torch.complex128` |

## Validation

```
129 passed, 3 skipped
```

The CUDA parity test is included and skips automatically when CUDA is unavailable.

Closes #8