### PR TITLE
Add robust singular-value filtering to InteractionMatrix

### DIFF
--- a/fiatlux/system/interaction_matrix.py
+++ b/fiatlux/system/interaction_matrix.py
@@ -144,29 +144,59 @@ class InteractionMatrix:
         """Calibrate the central derivative around the reference commands."""
         return self._calibrate(central=True, verbose=verbose)
 
-    def compute_control_matrix(self, n_modes: int = None):
-        """
-        Computes the pseudo-inverse (control matrix) via SVD.
-        n_modes : number of singular modes to keep (truncated SVD).
-        Returns the control matrix of shape (n_actuators, n_response).
+    def compute_control_matrix(
+        self,
+        n_modes: int | None = None,
+        *,
+        rcond: float | None = None,
+        atol: float = 0.0,
+    ) -> torch.Tensor:
+        """Compute a filtered SVD pseudo-inverse.
+
+        Singular values must be larger than both ``atol`` and
+        ``rcond * S.max()``. When ``rcond`` is omitted, the same
+        dimension-scaled machine-precision default as a conventional
+        pseudo-inverse is used. ``n_modes`` can additionally cap the number
+        of retained modes, ordered from largest to smallest singular value.
         """
         if self.matrix is None:
             raise RuntimeError(
                 "Call calibrate_one_sided() or calibrate_push_pull() first."
             )
 
+        if n_modes is not None and (
+            not isinstance(n_modes, int)
+            or isinstance(n_modes, bool)
+            or n_modes < 1
+        ):
+            raise ValueError("n_modes must be a positive integer or None.")
+        for name, value in (("rcond", rcond), ("atol", atol)):
+            if value is not None and (not math.isfinite(value) or value < 0):
+                raise ValueError(f"{name} must be a finite non-negative value.")
+
         self.U, self.S, self.Vh = torch.linalg.svd(self.matrix, full_matrices=False)
+        if rcond is None:
+            rcond = max(self.matrix.shape) * torch.finfo(self.S.dtype).eps
 
+        relative_threshold = rcond * self.S.max()
+        self.singular_value_threshold = max(
+            torch.as_tensor(atol, device=self.S.device, dtype=self.S.dtype),
+            relative_threshold,
+        )
+        retained = self.S > self.singular_value_threshold
         if n_modes is not None:
-            self.U, self.S, self.Vh = (
-                self.U[:, :n_modes],
-                self.S[:n_modes],
-                self.Vh[:n_modes, :],
-            )
+            mode_cap = torch.arange(self.S.numel(), device=self.S.device) < n_modes
+            retained &= mode_cap
 
+        self.retained_mode_indices = torch.nonzero(retained, as_tuple=False).flatten()
+        self.effective_rank = int(self.retained_mode_indices.numel())
+
+        inverse_singular_values = torch.zeros_like(self.S)
+        inverse_singular_values[retained] = self.S[retained].reciprocal()
         self.control_matrix = (
-            self.Vh.T @ torch.diag(1.0 / self.S) @ self.U.T
-        )  # (n_actuators, n_response)
+            self.Vh.T @ torch.diag(inverse_singular_values) @ self.U.T
+        )
+        return self.control_matrix
 
     def plot(self):
 

--- a/tests/test_interaction_matrix.py
+++ b/tests/test_interaction_matrix.py
@@ -135,3 +135,56 @@ def test_legacy_calibration_method_names_are_removed():
 
     assert not hasattr(calibration, "measure")
     assert not hasattr(calibration, "push_pull")
+
+
+def calibration_from_matrix(matrix):
+    calibration, _, _, _ = make_linear_calibration()
+    calibration.matrix = torch.as_tensor(matrix, dtype=torch.float64)
+    return calibration
+
+
+def test_zero_singular_value_is_safely_discarded():
+    calibration = calibration_from_matrix([[2.0, 0.0], [0.0, 0.0]])
+
+    control = calibration.compute_control_matrix()
+
+    assert torch.isfinite(control).all()
+    torch.testing.assert_close(control, torch.tensor([[0.5, 0.0], [0.0, 0.0]], dtype=torch.float64))
+    assert calibration.effective_rank == 1
+    assert calibration.retained_mode_indices.tolist() == [0]
+
+
+def test_relative_threshold_discards_poorly_conditioned_mode():
+    calibration = calibration_from_matrix([[10.0, 0.0], [0.0, 1e-4]])
+
+    calibration.compute_control_matrix(rcond=1e-3)
+
+    assert calibration.effective_rank == 1
+    assert calibration.retained_mode_indices.tolist() == [0]
+    assert calibration.S.tolist() == pytest.approx([10.0, 1e-4])
+
+
+def test_absolute_threshold_and_mode_cap_are_combined():
+    calibration = calibration_from_matrix(torch.diag(torch.tensor([4.0, 2.0, 1.0])))
+
+    calibration.compute_control_matrix(n_modes=2, rcond=0.0, atol=1.5)
+
+    assert calibration.retained_mode_indices.tolist() == [0, 1]
+    assert calibration.effective_rank == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"n_modes": 0},
+        {"n_modes": 1.5},
+        {"rcond": -1.0},
+        {"rcond": float("inf")},
+        {"atol": -1.0},
+    ],
+)
+def test_invalid_svd_filter_settings_are_rejected(kwargs):
+    calibration = calibration_from_matrix(torch.eye(2))
+
+    with pytest.raises(ValueError):
+        calibration.compute_control_matrix(**kwargs)


### PR DESCRIPTION
## Summary

- keep the complete SVD available for diagnostics
- discard numerically null singular values by default
- support relative (`rcond`) and absolute (`atol`) filtering
- retain `n_modes` as an additional upper bound
- expose `retained_mode_indices`, `effective_rank`, and `singular_value_threshold`
- return the computed control matrix

## Why

Directly evaluating `1 / S` produced infinities for null modes and unstable coefficients for poorly conditioned modes. The filtered inverse now assigns zero inverse gain to rejected modes.

## Validation

```
137 passed, 3 skipped
```

Includes regression tests for a null mode, relative and absolute thresholds, mode truncation, diagnostics, and invalid settings.

Closes #13