### PR TITLE
Support arbitrary InteractionMatrix measurement diagnostics

### DIFF
--- a/examples/interaction_matrix_diagnostics_validation.ipynb
+++ b/examples/interaction_matrix_diagnostics_validation.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "introduction",
+   "metadata": {},
+   "source": [
+    "# Interaction-matrix diagnostics: vector and rectangular measurements\n",
+    "\n",
+    "This notebook is the visual counterpart of `tests/test_interaction_matrix.py`. It uses a deterministic linear sensor so that calibration and reconstruction have an exact reference. The same six-component measurement is displayed first as a 1-D WFS vector and then as a rectangular `(2, 3)` image—no square-image assumption is required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "imports",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "\n",
+    "from fiatlux.system.interaction_matrix import InteractionMatrix\n",
+    "\n",
+    "torch.set_printoptions(precision=4, sci_mode=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "linear-model-heading",
+   "metadata": {},
+   "source": [
+    "## A deterministic linear DM and sensor\n",
+    "\n",
+    "The sensor follows $y = A c + b$. Push-pull calibration should therefore recover $A$ exactly, independently of the static background $b$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "linear-model",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LinearDM:\n",
+    "    def __init__(self, n_commands=3, stroke=1e-6):\n",
+    "        self._commands = torch.nn.Parameter(torch.zeros(n_commands, dtype=torch.float64))\n",
+    "        self.stroke = stroke\n",
+    "\n",
+    "    @property\n",
+    "    def commands(self):\n",
+    "        return self._commands\n",
+    "\n",
+    "    @commands.setter\n",
+    "    def commands(self, value):\n",
+    "        value = torch.as_tensor(value, device=self._commands.device, dtype=self._commands.dtype)\n",
+    "        with torch.no_grad():\n",
+    "            self._commands.copy_(value)\n",
+    "\n",
+    "\n",
+    "dm = LinearDM()\n",
+    "response_matrix = torch.tensor(\n",
+    "    [\n",
+    "        [2.0, -1.0, 0.5],\n",
+    "        [0.5, 3.0, -0.5],\n",
+    "        [-4.0, 2.0, 1.0],\n",
+    "        [1.5, 0.25, 2.0],\n",
+    "        [0.0, 1.0, -1.0],\n",
+    "        [2.5, -0.5, 1.5],\n",
+    "    ],\n",
+    "    dtype=torch.float64,\n",
+    ") * 1e8\n",
+    "background = torch.tensor([7.0, 11.0, -5.0, 2.0, 3.0, -1.0], dtype=torch.float64)\n",
+    "\n",
+    "def acquire_vector():\n",
+    "    return response_matrix @ dm.commands + background"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "calibration",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = InteractionMatrix(\n",
+    "    dm=dm,\n",
+    "    acquiring_function=acquire_vector,\n",
+    "    poke_amplitude=10e-9,\n",
+    ")\n",
+    "measured_matrix = calibration.calibrate_push_pull(verbose=False)\n",
+    "control_matrix = calibration.compute_control_matrix(rcond=1e-12)\n",
+    "\n",
+    "print(f'Matrix shape: {tuple(measured_matrix.shape)}')\n",
+    "print(f'Effective rank: {calibration.effective_rank}')\n",
+    "print(f'Retained modes: {calibration.retained_mode_indices.tolist()}')\n",
+    "print(f'Condition number: {calibration.condition_number:.3f}')\n",
+    "print(f'Max calibration error: {(measured_matrix - response_matrix).abs().max():.3e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "svd-heading",
+   "metadata": {},
+   "source": [
+    "## Singular values and 1-D measurement modes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "svd-plots",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration.plot_singular_values();\n",
+    "calibration.plot_modes();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rectangle-heading",
+   "metadata": {},
+   "source": [
+    "## The same modes as rectangular measurements\n",
+    "\n",
+    "The calibration remains a flat `(n_measurements, n_commands)` matrix. `measurement_shape` affects visualization only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "rectangle-plot",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration.plot_modes(measurement_shape=(2, 3));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "reconstruction-heading",
+   "metadata": {},
+   "source": [
+    "## Reconstruct a known command\n",
+    "\n",
+    "Subtracting the reference/background response gives the differential measurement expected by the control matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "reconstruction",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "injected = torch.tensor([80e-9, -35e-9, 20e-9], dtype=torch.float64)\n",
+    "differential_measurement = response_matrix @ injected\n",
+    "estimated = control_matrix @ differential_measurement\n",
+    "\n",
+    "print('Injected commands (nm):', injected * 1e9)\n",
+    "print('Estimated commands (nm):', estimated * 1e9)\n",
+    "torch.testing.assert_close(estimated, injected, rtol=1e-10, atol=1e-15)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fiatlux/system/interaction_matrix.py
+++ b/fiatlux/system/interaction_matrix.py
@@ -2,8 +2,6 @@ import math
 import torch
 from typing import Callable
 
-import matplotlib.pyplot as plt
-
 from fiatlux.optics.elements.deformable_mirror import DeformableMirror
 
 
@@ -60,6 +58,23 @@ class InteractionMatrix:
         self._measurement_dtype: torch.dtype | None = None
         self._measurement_device: torch.device | None = None
         self.matrix: torch.Tensor | None = None
+
+    @property
+    def singular_values(self) -> torch.Tensor:
+        """Complete singular-value spectrum from the latest inversion."""
+        if not hasattr(self, "S"):
+            raise RuntimeError("Call compute_control_matrix() first.")
+        return self.S
+
+    @property
+    def condition_number(self) -> float:
+        """Condition number of the retained singular subspace."""
+        if not hasattr(self, "retained_mode_indices"):
+            raise RuntimeError("Call compute_control_matrix() first.")
+        if self.effective_rank == 0:
+            return math.inf
+        retained = self.S[self.retained_mode_indices]
+        return (retained.max() / retained.min()).item()
 
     def _get_response(self, expected_shape: torch.Size | None = None) -> torch.Tensor:
         """Acquire and validate one measurement without changing its shape."""
@@ -198,40 +213,92 @@ class InteractionMatrix:
         )
         return self.control_matrix
 
-    def plot(self):
+    def plot_singular_values(self):
+        """Plot the full spectrum and mark the retained SVD modes."""
+        import matplotlib.pyplot as plt
 
-        plt.figure()
-        plt.plot(self.S)
-        plt.yscale("log")
-        plt.xlabel("Mode index")
-        plt.ylabel("Singular value")
-        plt.title("Singular values of the interaction matrix")
-        plt.grid()
-        plt.draw()
+        singular_values = self.singular_values.detach().cpu()
+        fig, ax = plt.subplots()
+        ax.semilogy(singular_values, marker="o", label="all modes")
+        if self.effective_rank:
+            indices = self.retained_mode_indices.detach().cpu()
+            ax.semilogy(
+                indices,
+                singular_values[indices],
+                linestyle="none",
+                marker="o",
+                label="retained",
+            )
+        ax.axhline(
+            self.singular_value_threshold.detach().cpu().item(),
+            color="tab:red",
+            linestyle="--",
+            label="threshold",
+        )
+        ax.set_xlabel("Mode index")
+        ax.set_ylabel("Singular value")
+        ax.set_title("Interaction-matrix singular values")
+        ax.grid(True)
+        ax.legend()
+        return fig, ax
 
-        N = self.dm._commands.numel()
-        n = torch.tensor(N**0.5).ceil().int().item()
+    def plot_modes(
+        self,
+        measurement_shape: tuple[int, ...] | torch.Size | None = None,
+        *,
+        max_modes: int | None = None,
+    ):
+        """Plot retained measurement modes as curves or 2-D images.
 
-        fig, axes = plt.subplots(n, n, figsize=(10, 10))
-        fig_out, axes_out = plt.subplots(n, n, figsize=(10, 10))
+        A one-dimensional measurement is plotted as a curve. A two-dimensional
+        measurement is displayed as an image. Higher-dimensional measurements
+        require the caller to provide a one- or two-dimensional display shape.
+        """
+        import matplotlib.pyplot as plt
 
-        n_reshape = int(self.control_matrix.shape[1] ** 0.5)
+        _ = self.singular_values
+        shape = self.measurement_shape if measurement_shape is None else measurement_shape
+        if shape is None:
+            shape = (self.matrix.shape[0],)
+        shape = tuple(shape)
+        if len(shape) not in (1, 2) or math.prod(shape) != self.matrix.shape[0]:
+            raise ValueError(
+                "measurement_shape must be one- or two-dimensional and contain "
+                f"{self.matrix.shape[0]} values."
+            )
+        if max_modes is not None and (
+            not isinstance(max_modes, int)
+            or isinstance(max_modes, bool)
+            or max_modes < 1
+        ):
+            raise ValueError("max_modes must be a positive integer or None.")
 
-        for i in range(N):
+        indices = self.retained_mode_indices
+        if max_modes is not None:
+            indices = indices[:max_modes]
+        n_plots = max(1, indices.numel())
+        n_columns = min(4, n_plots)
+        n_rows = math.ceil(n_plots / n_columns)
+        fig, axes = plt.subplots(
+            n_rows, n_columns, squeeze=False, figsize=(3 * n_columns, 3 * n_rows)
+        )
+        for ax in axes.flat:
+            ax.set_visible(False)
+        for ax, index in zip(axes.flat, indices.tolist()):
+            ax.set_visible(True)
+            mode = self.U[:, index].detach().cpu().reshape(shape)
+            if len(shape) == 1:
+                ax.plot(mode)
+                ax.set_xlabel("Measurement index")
+            else:
+                ax.imshow(mode.numpy())
+                ax.axis("off")
+            ax.set_title(f"Mode {index}")
+        fig.tight_layout()
+        return fig, axes
 
-            ax = axes[i // n, i % n]
-            ax_out = axes_out[i // n, i % n]
-
-            mode = self.U[:, i].reshape(n_reshape, n_reshape)
-            mode_in = self.matrix[:, i].reshape(n_reshape, n_reshape)
-
-            ax.imshow(mode_in)
-            ax.set_title(f"Mode {i}")
-            ax.axis("off")
-
-            ax_out.imshow(mode)
-            ax_out.set_title(f"Mode {i}")
-            ax_out.axis("off")
-
-        plt.tight_layout()
-        plt.draw()
+    def plot(self, measurement_shape=None, *, max_modes=None):
+        """Compatibility helper returning singular-value and mode figures."""
+        singular_figure = self.plot_singular_values()
+        mode_figure = self.plot_modes(measurement_shape, max_modes=max_modes)
+        return singular_figure, mode_figure

--- a/tests/test_interaction_matrix.py
+++ b/tests/test_interaction_matrix.py
@@ -188,3 +188,59 @@ def test_invalid_svd_filter_settings_are_rejected(kwargs):
 
     with pytest.raises(ValueError):
         calibration.compute_control_matrix(**kwargs)
+
+
+def test_svd_diagnostics_are_exposed():
+    calibration = calibration_from_matrix([[4.0, 0.0], [0.0, 2.0]])
+
+    calibration.compute_control_matrix()
+
+    torch.testing.assert_close(
+        calibration.singular_values, torch.tensor([4.0, 2.0], dtype=torch.float64)
+    )
+    assert calibration.condition_number == pytest.approx(2.0)
+
+
+def test_diagnostics_require_control_matrix_computation():
+    calibration = calibration_from_matrix(torch.eye(2))
+
+    with pytest.raises(RuntimeError, match="compute_control_matrix"):
+        _ = calibration.singular_values
+    with pytest.raises(RuntimeError, match="compute_control_matrix"):
+        _ = calibration.condition_number
+
+
+def test_plot_modes_supports_one_dimensional_measurements():
+    import matplotlib.pyplot as plt
+
+    calibration = calibration_from_matrix(
+        [[2.0, 0.0], [1.0, 1.0], [0.0, 2.0]]
+    )
+    calibration.measurement_shape = torch.Size([3])
+    calibration.compute_control_matrix()
+
+    figure, axes = calibration.plot_modes()
+
+    assert len(axes.flat[0].lines) == 1
+    plt.close(figure)
+
+
+def test_plot_modes_supports_explicit_rectangular_shape():
+    import matplotlib.pyplot as plt
+
+    calibration = calibration_from_matrix(torch.arange(12).reshape(6, 2))
+    calibration.compute_control_matrix()
+
+    figure, axes = calibration.plot_modes(measurement_shape=(2, 3))
+
+    assert axes.flat[0].images[0].get_array().shape == (2, 3)
+    plt.close(figure)
+
+
+@pytest.mark.parametrize("shape", [(2, 2), (1, 2, 3)])
+def test_plot_modes_rejects_incompatible_display_shape(shape):
+    calibration = calibration_from_matrix(torch.arange(12).reshape(6, 2))
+    calibration.compute_control_matrix()
+
+    with pytest.raises(ValueError, match="measurement_shape"):
+        calibration.plot_modes(measurement_shape=shape)


### PR DESCRIPTION
## Summary

- expose the complete singular-value spectrum and retained-subspace condition number
- split singular-value and measurement-mode visualization into explicit helpers
- plot 1-D WFS measurements as curves
- plot 2-D measurements using their actual, optionally supplied shape
- reject incompatible or higher-dimensional display shapes with an actionable error
- keep a compatibility `plot()` wrapper without square-image assumptions
- move Matplotlib imports out of the numerical module import path
- add an executable visual notebook with calibration, SVD diagnostics, vector/rectangular displays, and command reconstruction

## Validation

```
143 passed, 3 skipped
```

The notebook cells were also executed headlessly and recover the injected commands to numerical precision.

Regression coverage includes 1-D vectors, explicit rectangular images, invalid display shapes, condition-number diagnostics, and use-before-computation errors.

Closes #14