### PR TITLE
Fix JSON loader for the current SerialSystem API

### DIFF
--- a/config/minimal.json
+++ b/config/minimal.json
@@ -1,0 +1,36 @@
+{
+    "source": {
+        "spectrum": {
+            "magnitude": 0,
+            "band": "HCM2",
+            "samples": 2
+        }
+    },
+    "pupil_grid": {
+        "nx": 8,
+        "ny": 6,
+        "dx": 0.1,
+        "dy": 0.12
+    },
+    "focal_grid": {
+        "nx": 10,
+        "ny": 4,
+        "dx": 1e-6,
+        "dy": 1.5e-6
+    },
+    "serial_elements": {
+        "CircularAperture_0": {
+            "grid": "pupil_grid",
+            "radius": 0.31
+        },
+        "MFTPropagator_0": {
+            "focal_length": 2.0,
+            "output_grid": "focal_grid"
+        }
+    },
+    "detector": {
+        "grid": "focal_grid",
+        "exposure_time": 1.0,
+        "quantum_efficiency": 1.0
+    }
+}

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -70,7 +70,7 @@ from .optics.elements.mask import (
 # Config system
 # =========================
 
-from .config.loader import from_json
+from .config.loader import SimulationSetup, from_json
 from .config.builder import build_serial_elements
 
 # =========================
@@ -132,5 +132,6 @@ __all__ = [
     "HarmoniResiduals",
     # Config
     "from_json",
+    "SimulationSetup",
     "build_serial_elements",
 ]

--- a/fiatlux/config/loader.py
+++ b/fiatlux/config/loader.py
@@ -1,9 +1,12 @@
 import json
+from dataclasses import dataclass
+from pathlib import Path
 
 from fiatlux.core.grid import Grid
 from fiatlux.core.source import PlaneWave
-from fiatlux.optics.elements.mask import *
-from fiatlux.optics.elements.deformable_mirror import *
+from fiatlux.optics.elements import mask as _mask_types
+from fiatlux.optics.elements import deformable_mirror as _dm_types
+from fiatlux.optics import propagator as _propagator_types
 
 from fiatlux.config.builder import (
     build_serial_elements,
@@ -18,7 +21,21 @@ from fiatlux.optics.detector import Detector
 from fiatlux.system.optical_system import SerialSystem
 
 
-def from_json(path):
+@dataclass
+class SimulationSetup:
+    """Objects required to execute a simulation loaded from configuration."""
+
+    system: SerialSystem
+    source: PlaneWave
+    detector: Detector
+    objects: dict[str, object]
+
+    def run(self):
+        return self.system.run(self.source, self.detector)
+
+
+def from_json(path: str | Path) -> SimulationSetup:
+    """Build a source, ordered optical system and detector from JSON."""
 
     with open(path) as f:
         config = json.load(f)
@@ -33,9 +50,16 @@ def from_json(path):
 
     band = PhotometricBand[spec_cfg["band"]]
 
-    spectrum = Spectrum.from_sampling(
-        magnitude=spec_cfg["magnitude"], band=band, Nu=spec_cfg["Nu"]
-    )
+    if "samples" in spec_cfg:
+        spectrum = Spectrum(
+            magnitude=spec_cfg["magnitude"],
+            band=band,
+            samples=spec_cfg["samples"],
+        )
+    else:
+        spectrum = Spectrum.from_sampling(
+            magnitude=spec_cfg["magnitude"], band=band, Nu=spec_cfg["Nu"]
+        )
 
     source = PlaneWave(spectrum=spectrum)
 
@@ -62,12 +86,22 @@ def from_json(path):
     # Detector
     # ------------------
 
-    detector = Detector(grid=pupil_grid)
+    detector_cfg = dict(config["detector"])
+    detector_grid_name = detector_cfg.pop("grid")
+    try:
+        detector_grid = objects[detector_grid_name]
+    except KeyError as error:
+        raise ValueError(
+            f"Unknown detector grid reference '{detector_grid_name}'."
+        ) from error
+    detector = Detector(grid=detector_grid, **detector_cfg)
+    objects["detector"] = detector
 
     # ------------------
     # System
     # ------------------
 
-    system = SerialSystem(source=source, detector=detector, elements=serial_elements)
+    system = SerialSystem(elements=serial_elements)
+    objects["system"] = system
 
-    return system
+    return SimulationSetup(system, source, detector, objects)

--- a/fiatlux/optics/propagator.py
+++ b/fiatlux/optics/propagator.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 from fiatlux.core.field import Field
 from fiatlux.core.grid import Grid
+from fiatlux.config.registry import register_type
 
 import torch
 
@@ -11,6 +12,7 @@ class Propagator(ABC): ...
 
 
 @dataclass
+@register_type("MFTPropagator")
 class MFTPropagator(Propagator):
     focal_length: float
     output_grid: Grid
@@ -69,6 +71,7 @@ class MFTPropagator(Propagator):
         return ">"
 
 @dataclass
+@register_type("IdentityPropagator")
 class IdentityPropagator(Propagator):
     grid: Grid
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from fiatlux.config.loader import SimulationSetup, from_json
+from fiatlux.core.grid import Grid
+from fiatlux.core.source import PlaneWave
+from fiatlux.core.spectrum import PhotometricBand, Spectrum
+from fiatlux.optics.detector import Detector
+from fiatlux.optics.elements.mask import CircularAperture
+from fiatlux.optics.propagator import MFTPropagator
+from fiatlux.system.optical_system import SerialSystem
+
+
+CONFIG_PATH = Path(__file__).parents[1] / "config" / "minimal.json"
+
+
+def build_equivalent_python_setup():
+    pupil_grid = Grid(nx=8, ny=6, dx=0.1, dy=0.12)
+    focal_grid = Grid(nx=10, ny=4, dx=1e-6, dy=1.5e-6)
+    source = PlaneWave(Spectrum(0, PhotometricBand.HCM2, samples=2))
+    elements = [
+        CircularAperture(pupil_grid, radius=0.31),
+        MFTPropagator(focal_length=2.0, output_grid=focal_grid),
+    ]
+    detector = Detector(focal_grid, exposure_time=1.0, quantum_efficiency=1.0)
+    return SimulationSetup(SerialSystem(elements), source, detector, {})
+
+
+def test_minimal_json_builds_current_serial_system_api():
+    setup = from_json(CONFIG_PATH)
+
+    assert isinstance(setup, SimulationSetup)
+    assert isinstance(setup.system, SerialSystem)
+    assert [type(element) for element in setup.system.elements] == [
+        CircularAperture,
+        MFTPropagator,
+    ]
+    assert setup.detector.grid is setup.objects["focal_grid"]
+
+
+def test_json_and_python_systems_produce_equivalent_results():
+    configured = from_json(CONFIG_PATH)
+    python = build_equivalent_python_setup()
+
+    configured_result = configured.run()
+    python_result = python.run()
+
+    torch.testing.assert_close(
+        configured.detector.image_buffer,
+        python.detector.image_buffer,
+    )
+    torch.testing.assert_close(
+        configured_result.steps[-1].field_after.complex_amplitude,
+        python_result.steps[-1].field_after.complex_amplitude,
+    )
+
+
+def test_unknown_detector_grid_has_actionable_error(tmp_path):
+    config = json.loads(CONFIG_PATH.read_text())
+    config["detector"]["grid"] = "missing_grid"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="Unknown detector grid reference"):
+        from_json(path)


### PR DESCRIPTION
## Summary

- construct `SerialSystem` with its current elements-only constructor
- return a typed `SimulationSetup` containing the system, source, detector, and named objects
- provide `SimulationSetup.run()` for direct configured execution
- build the detector from its JSON parameters and referenced grid
- register MFT and identity propagators for configuration construction
- support explicit spectral `samples` while preserving `Nu` sampling
- replace wildcard imports in the loader with explicit registration imports
- add a minimal runnable JSON configuration

## Validation

```
150 passed, 3 skipped
```

The regression test constructs equivalent JSON and Python systems and compares both the propagated complex field and detector image.

This PR intentionally leaves expression-evaluation hardening to #18.

Closes #17