### PR TITLE
Replace unrestricted config eval with a safe expression evaluator

### DIFF
--- a/fiatlux/config/resolver.py
+++ b/fiatlux/config/resolver.py
@@ -1,3 +1,25 @@
+import ast
+import math
+import operator
+
+
+_BINARY_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_UNARY_OPERATORS = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+_SAFE_METHODS = {"max", "min", "mean", "sum", "sqrt", "item"}
+_CONSTANTS = {"pi": math.pi}
+
+
 def resolve_reference(value, objects):
     """
     Replace string references by real objects.
@@ -15,20 +37,86 @@ def resolve_reference(value, objects):
 
 
 def evaluate_expression(value, context):
-    """
-    Evaluate expressions like:
+    """Evaluate a restricted configuration expression.
 
-        "source.spectrum.wavelength.max()"
+    Supported syntax consists of numeric constants, named configuration
+    objects, public attribute access, arithmetic, and a small allowlist of
+    zero-argument numerical methods. No Python builtins are available and
+    arbitrary function calls, indexing, comprehensions, and private
+    attributes are rejected.
     """
 
     if not isinstance(value, str):
         return value
-
-    if "." not in value:
+    if "/" in value and value.rsplit("/", 1)[-1].count(".") == 1:
+        # File paths such as ``data/pupil.fits`` are configuration literals,
+        # not division expressions.
         return value
 
     try:
-        return eval(value, {}, context)
-
-    except Exception:
+        expression = ast.parse(value, mode="eval")
+    except SyntaxError:
         return value
+
+    root = expression.body
+    is_context_reference = (
+        isinstance(root, (ast.Attribute, ast.Name, ast.Call))
+        and _root_name(root) in context
+    )
+    is_arithmetic = isinstance(root, (ast.BinOp, ast.UnaryOp))
+    if not is_context_reference and not is_arithmetic:
+        if isinstance(root, (ast.Name, ast.Constant, ast.Attribute)):
+            return value
+        raise ValueError(f"Unsupported configuration expression: {value!r}.")
+
+    try:
+        return _evaluate_node(root, context)
+    except (AttributeError, KeyError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"Unsupported configuration expression {value!r}: {error}"
+        ) from error
+
+
+def _root_name(node: ast.AST) -> str | None:
+    while isinstance(node, (ast.Attribute, ast.Call)):
+        node = node.value if isinstance(node, ast.Attribute) else node.func
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _evaluate_node(node: ast.AST, context):
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
+            return node.value
+        raise ValueError("only numeric constants are allowed")
+
+    if isinstance(node, ast.Name):
+        if node.id in context:
+            return context[node.id]
+        if node.id in _CONSTANTS:
+            return _CONSTANTS[node.id]
+        raise ValueError(f"unknown name '{node.id}'")
+
+    if isinstance(node, ast.Attribute):
+        if node.attr.startswith("_"):
+            raise ValueError("private attributes are not allowed")
+        return getattr(_evaluate_node(node.value, context), node.attr)
+
+    if isinstance(node, ast.BinOp) and type(node.op) in _BINARY_OPERATORS:
+        left = _evaluate_node(node.left, context)
+        right = _evaluate_node(node.right, context)
+        return _BINARY_OPERATORS[type(node.op)](left, right)
+
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY_OPERATORS:
+        return _UNARY_OPERATORS[type(node.op)](_evaluate_node(node.operand, context))
+
+    if isinstance(node, ast.Call):
+        if node.args or node.keywords or not isinstance(node.func, ast.Attribute):
+            raise ValueError("only allowlisted zero-argument methods are allowed")
+        if node.func.attr not in _SAFE_METHODS:
+            raise ValueError(f"method '{node.func.attr}' is not allowed")
+        method = _evaluate_node(node.func, context)
+        if not callable(method):
+            raise ValueError(f"attribute '{node.func.attr}' is not callable")
+        return method()
+
+    raise ValueError(f"syntax '{type(node).__name__}' is not allowed")

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from fiatlux.config.resolver import evaluate_expression, resolve_reference
+
+
+def make_context():
+    spectrum = SimpleNamespace(
+        wavelengths=torch.tensor([1.0e-6, 1.2e-6], dtype=torch.float64)
+    )
+    return {"source": SimpleNamespace(spectrum=spectrum), "radius": 0.5}
+
+
+def test_exact_object_reference_is_resolved():
+    context = make_context()
+
+    assert resolve_reference("source", context) is context["source"]
+
+
+def test_public_attributes_arithmetic_and_safe_method_are_supported():
+    context = make_context()
+
+    result = evaluate_expression(
+        "source.spectrum.wavelengths.max() / (2 * radius)", context
+    )
+
+    torch.testing.assert_close(result, torch.tensor(1.2e-6, dtype=torch.float64))
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "__import__('os').system('touch forbidden')",
+        "source.__class__",
+        "source.spectrum.wavelengths.tolist()",
+        "source.spectrum.wavelengths[0]",
+        "[value for value in source.spectrum.wavelengths]",
+        "lambda: 1",
+    ],
+)
+def test_unsafe_or_unsupported_python_is_rejected(expression):
+    with pytest.raises(ValueError, match="Unsupported configuration expression"):
+        evaluate_expression(expression, make_context())
+
+
+@pytest.mark.parametrize("literal", ["HCM2", "data/file.fits", "file.fits"])
+def test_plain_configuration_strings_remain_literals(literal):
+    assert evaluate_expression(literal, make_context()) == literal
+
+
+def test_unknown_name_in_arithmetic_has_actionable_error():
+    with pytest.raises(ValueError, match="unknown name 'missing'"):
+        evaluate_expression("missing * 2", make_context())


### PR DESCRIPTION
## Summary

- remove unrestricted Python `eval()` from configuration parsing
- parse supported expressions with `ast`
- allow numeric constants, named configuration objects, public attributes, arithmetic, and an explicit set of zero-argument numerical reductions
- reject imports, arbitrary calls, indexing, comprehensions, lambdas, private attributes, call arguments, and unknown arithmetic names
- preserve ordinary strings and file paths as literals
- return actionable errors containing the rejected expression

## Supported example

```text
source.spectrum.wavelengths.max() / (2 * radius)
```

## Validation

```
162 passed, 3 skipped
```

Security regression tests cover import/system-call attempts, private attribute traversal, non-allowlisted methods, indexing, comprehensions, lambdas, and unknown names.

Closes #18