### PR TITLE
Add configuration schema and early validation

### DIFF
--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -72,6 +72,7 @@ from .optics.elements.mask import (
 
 from .config.loader import SimulationSetup, from_json
 from .config.builder import build_serial_elements
+from .config.schema import ConfigurationError, validate_config
 
 # =========================
 # Utilities
@@ -133,5 +134,7 @@ __all__ = [
     # Config
     "from_json",
     "SimulationSetup",
+    "ConfigurationError",
+    "validate_config",
     "build_serial_elements",
 ]

--- a/fiatlux/config/loader.py
+++ b/fiatlux/config/loader.py
@@ -11,6 +11,7 @@ from fiatlux.optics import propagator as _propagator_types
 from fiatlux.config.builder import (
     build_serial_elements,
 )
+from fiatlux.config.schema import ConfigurationError, validate_config
 
 from fiatlux.core.spectrum import (
     Spectrum,
@@ -37,8 +38,15 @@ class SimulationSetup:
 def from_json(path: str | Path) -> SimulationSetup:
     """Build a source, ordered optical system and detector from JSON."""
 
-    with open(path) as f:
-        config = json.load(f)
+    try:
+        with open(path) as f:
+            config = json.load(f)
+    except json.JSONDecodeError as error:
+        raise ConfigurationError(
+            f"Invalid JSON at line {error.lineno}, column {error.colno}: {error.msg}."
+        ) from error
+
+    validate_config(config)
 
     objects = {}
 
@@ -48,7 +56,12 @@ def from_json(path: str | Path) -> SimulationSetup:
 
     spec_cfg = config["source"]["spectrum"]
 
-    band = PhotometricBand[spec_cfg["band"]]
+    try:
+        band = PhotometricBand[spec_cfg["band"]]
+    except KeyError as error:
+        raise ConfigurationError(
+            f"source.spectrum.band: {error.args[0]}"
+        ) from error
 
     if "samples" in spec_cfg:
         spectrum = Spectrum(
@@ -80,7 +93,10 @@ def from_json(path: str | Path) -> SimulationSetup:
     # Serial elements
     # ------------------
 
-    serial_elements = build_serial_elements(config["serial_elements"], objects)
+    try:
+        serial_elements = build_serial_elements(config["serial_elements"], objects)
+    except (TypeError, ValueError) as error:
+        raise ConfigurationError(f"serial_elements: {error}") from error
 
     # ------------------
     # Detector
@@ -94,7 +110,10 @@ def from_json(path: str | Path) -> SimulationSetup:
         raise ValueError(
             f"Unknown detector grid reference '{detector_grid_name}'."
         ) from error
-    detector = Detector(grid=detector_grid, **detector_cfg)
+    try:
+        detector = Detector(grid=detector_grid, **detector_cfg)
+    except (TypeError, ValueError) as error:
+        raise ConfigurationError(f"detector: {error}") from error
     objects["detector"] = detector
 
     # ------------------
@@ -102,6 +121,35 @@ def from_json(path: str | Path) -> SimulationSetup:
     # ------------------
 
     system = SerialSystem(elements=serial_elements)
+    _validate_grid_chain(system, detector)
     objects["system"] = system
 
     return SimulationSetup(system, source, detector, objects)
+
+
+def _validate_grid_chain(system: SerialSystem, detector: Detector) -> None:
+    """Reject incompatible element and detector grids before propagation."""
+    current_grid = getattr(system.elements[0], "grid", None)
+    if current_grid is None:
+        current_grid = getattr(system.elements[0], "pixel_grid", None)
+    if current_grid is None:
+        raise ConfigurationError(
+            "serial_elements.0 does not define the source-generation grid."
+        )
+
+    for index, element in enumerate(system.elements):
+        expected_grid = getattr(element, "pixel_grid", None)
+        if expected_grid is None and not hasattr(element, "output_grid"):
+            expected_grid = getattr(element, "grid", None)
+        if expected_grid is not None and expected_grid != current_grid:
+            raise ConfigurationError(
+                f"serial_elements.{index} ({type(element).__name__}) uses a grid "
+                "incompatible with the preceding optical plane."
+            )
+        if hasattr(element, "output_grid"):
+            current_grid = element.output_grid
+
+    if detector.grid != current_grid:
+        raise ConfigurationError(
+            "detector.grid is incompatible with the final optical plane."
+        )

--- a/fiatlux/config/schema.py
+++ b/fiatlux/config/schema.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import inspect
+import math
+from collections.abc import Mapping
+
+from fiatlux.config.registry import TYPE_REGISTRY
+
+
+class ConfigurationError(ValueError):
+    """Invalid Fiatlux configuration with a path to the offending field."""
+
+
+def _mapping(value, path: str) -> Mapping:
+    if not isinstance(value, Mapping):
+        raise ConfigurationError(f"{path} must be a JSON object.")
+    return value
+
+
+def _fields(value, path: str, *, required, allowed):
+    mapping = _mapping(value, path)
+    missing = sorted(set(required) - mapping.keys())
+    unknown = sorted(mapping.keys() - set(allowed))
+    if missing:
+        raise ConfigurationError(f"{path} is missing required field '{missing[0]}'.")
+    if unknown:
+        raise ConfigurationError(f"{path} contains unknown field '{unknown[0]}'.")
+    return mapping
+
+
+def _positive_integer(value, path: str):
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ConfigurationError(f"{path} must be a positive integer.")
+
+
+def _finite_number(value, path: str):
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+    ):
+        raise ConfigurationError(f"{path} must be a finite number.")
+
+
+def _validate_grid(config, path: str):
+    config = _fields(
+        config,
+        path,
+        required={"nx", "ny", "dx", "dy"},
+        allowed={"nx", "ny", "dx", "dy", "device"},
+    )
+    _positive_integer(config["nx"], f"{path}.nx")
+    _positive_integer(config["ny"], f"{path}.ny")
+    for name in ("dx", "dy"):
+        _finite_number(config[name], f"{path}.{name}")
+        if config[name] <= 0:
+            raise ConfigurationError(f"{path}.{name} must be positive.")
+    if "device" in config and not isinstance(config["device"], str):
+        raise ConfigurationError(f"{path}.device must be a string.")
+
+
+def _validate_spectrum(config):
+    config = _fields(
+        config,
+        "source.spectrum",
+        required={"magnitude", "band"},
+        allowed={"magnitude", "band", "samples", "Nu"},
+    )
+    _finite_number(config["magnitude"], "source.spectrum.magnitude")
+    if not isinstance(config["band"], str):
+        raise ConfigurationError("source.spectrum.band must be a string.")
+    sampling_fields = [name for name in ("samples", "Nu") if name in config]
+    if len(sampling_fields) != 1:
+        raise ConfigurationError(
+            "source.spectrum must contain exactly one of 'samples' or 'Nu'."
+        )
+    name = sampling_fields[0]
+    _positive_integer(config[name], f"source.spectrum.{name}")
+
+
+def _validate_element(name: str, params):
+    path = f"serial_elements.{name}"
+    if not isinstance(name, str):
+        raise ConfigurationError("serial_elements names must be strings.")
+    type_name = name.split("_")[0]
+    if type_name not in TYPE_REGISTRY:
+        raise ConfigurationError(f"{path} has unknown optical type '{type_name}'.")
+    params = _mapping(params, path)
+    signature = inspect.signature(TYPE_REGISTRY[type_name])
+    constructor_parameters = {
+        key: parameter
+        for key, parameter in signature.parameters.items()
+        if key != "self"
+        and parameter.kind
+        not in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD)
+    }
+    unknown = sorted(params.keys() - constructor_parameters.keys())
+    if unknown:
+        raise ConfigurationError(f"{path} contains unknown field '{unknown[0]}'.")
+    required = {
+        key
+        for key, parameter in constructor_parameters.items()
+        if parameter.default is inspect.Parameter.empty
+    }
+    missing = sorted(required - params.keys())
+    if missing:
+        raise ConfigurationError(f"{path} is missing required field '{missing[0]}'.")
+
+
+def validate_config(config) -> None:
+    """Validate the static structure and primitive types of a system config."""
+    config = _fields(
+        config,
+        "config",
+        required={"source", "pupil_grid", "focal_grid", "serial_elements", "detector"},
+        allowed={"source", "pupil_grid", "focal_grid", "serial_elements", "detector"},
+    )
+    source = _fields(
+        config["source"], "source", required={"spectrum"}, allowed={"spectrum"}
+    )
+    _validate_spectrum(source["spectrum"])
+    _validate_grid(config["pupil_grid"], "pupil_grid")
+    _validate_grid(config["focal_grid"], "focal_grid")
+
+    elements = _mapping(config["serial_elements"], "serial_elements")
+    if not elements:
+        raise ConfigurationError("serial_elements must contain at least one element.")
+    for name, params in elements.items():
+        _validate_element(name, params)
+
+    detector = _mapping(config["detector"], "detector")
+    if "grid" not in detector:
+        raise ConfigurationError("detector is missing required field 'grid'.")
+    if not isinstance(detector["grid"], str):
+        raise ConfigurationError("detector.grid must be an object-reference string.")

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,82 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from fiatlux.config.loader import from_json
+from fiatlux.config.schema import ConfigurationError, validate_config
+
+CONFIG_PATH = Path(__file__).parents[1] / "config" / "minimal.json"
+
+
+@pytest.fixture
+def valid_config():
+    return json.loads(CONFIG_PATH.read_text())
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (lambda cfg: cfg.pop("detector"), "config is missing required field 'detector'"),
+        (
+            lambda cfg: cfg["source"]["spectrum"].update(samples=0),
+            "source.spectrum.samples must be a positive integer",
+        ),
+        (
+            lambda cfg: cfg["source"]["spectrum"].update(Nu=4),
+            "exactly one of 'samples' or 'Nu'",
+        ),
+        (
+            lambda cfg: cfg["serial_elements"].update(Unknown_0={}),
+            "unknown optical type 'Unknown'",
+        ),
+        (
+            lambda cfg: cfg["serial_elements"]["CircularAperture_0"].update(
+                nonsense=1
+            ),
+            "contains unknown field 'nonsense'",
+        ),
+    ],
+)
+def test_static_schema_errors_include_field_path(valid_config, mutation, message):
+    config = deepcopy(valid_config)
+    mutation(config)
+
+    with pytest.raises(ConfigurationError, match=message):
+        validate_config(config)
+
+
+def test_invalid_band_is_reported_before_simulation(valid_config, tmp_path):
+    valid_config["source"]["spectrum"]["band"] = "NOT_A_BAND"
+    path = tmp_path / "invalid_band.json"
+    path.write_text(json.dumps(valid_config))
+
+    with pytest.raises(ConfigurationError, match="source.spectrum.band"):
+        from_json(path)
+
+
+def test_malformed_detector_is_reported_with_section_name(valid_config, tmp_path):
+    valid_config["detector"]["exposure_time"] = -1
+    path = tmp_path / "invalid_detector.json"
+    path.write_text(json.dumps(valid_config))
+
+    with pytest.raises(ConfigurationError, match="detector: exposure_time"):
+        from_json(path)
+
+
+def test_incompatible_detector_grid_is_rejected_before_run(valid_config, tmp_path):
+    valid_config["detector"]["grid"] = "pupil_grid"
+    path = tmp_path / "wrong_detector_grid.json"
+    path.write_text(json.dumps(valid_config))
+
+    with pytest.raises(ConfigurationError, match="final optical plane"):
+        from_json(path)
+
+
+def test_malformed_json_reports_location(tmp_path):
+    path = tmp_path / "malformed.json"
+    path.write_text('{"source": }')
+
+    with pytest.raises(ConfigurationError, match="line 1, column"):
+        from_json(path)


### PR DESCRIPTION
## Summary

- add a dependency-free schema validator for Fiatlux JSON configurations
- validate required and unknown fields with precise configuration paths
- validate spectrum sampling, grid dimensions/spacings, and primitive types
- reject unknown optical element types and constructor parameters
- wrap invalid bands, element construction, and detector parameters in actionable `ConfigurationError` messages
- validate optical-plane grid continuity and the final detector grid before propagation
- report malformed JSON with its line and column
- expose `ConfigurationError` and `validate_config` publicly

## Validation

```
171 passed, 3 skipped
```

Coverage includes missing fields, invalid samples, conflicting sampling definitions, unknown elements and parameters, invalid bands, malformed detector settings, incompatible grids, and malformed JSON.

Closes #19