### PR TITLE
Complete the core pytest test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,20 @@ fiatlux/
 
 The separation between **physical fields**, **optical components**, and **system orchestration** is central to the Fiatlux 2.0 architecture.
 
+## Testing
+
+Install the development dependencies and run the complete core suite from the
+repository root:
+
+```bash
+python -m pip install pytest
+python -m pytest -q
+```
+
+The suite covers grids, fields, spectra, sources, masks, propagators, detectors,
+deformable mirrors, atmosphere/NCPA models, interaction matrices, configuration,
+and CPU/GPU consistency when CUDA is available.
+
 ## Maintenance policy
 
 - `fiatlux/` contains the supported package API.

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+
+
+def test_grid_coordinates_are_centered_and_use_declared_state():
+    grid = Grid(5, 3, 0.2, 0.4, dtype=torch.float64)
+
+    torch.testing.assert_close(
+        grid.x, torch.tensor([-0.4, -0.2, 0.0, 0.2, 0.4], dtype=torch.float64)
+    )
+    torch.testing.assert_close(
+        grid.y, torch.tensor([-0.4, 0.0, 0.4], dtype=torch.float64)
+    )
+    assert grid.meshgrid()[0].shape == grid.shape == (3, 5)
+    assert grid.x.device == grid.device
+
+
+def test_grid_to_returns_new_grid_without_mutating_source():
+    grid = Grid(4, 2, 0.1, 0.2)
+
+    converted = grid.to(dtype=torch.float64)
+
+    assert converted is not grid
+    assert converted.dtype == torch.float64
+    assert grid.dtype == torch.float32
+    assert (converted.nx, converted.ny, converted.dx, converted.dy) == (4, 2, 0.1, 0.2)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"nx": 0},
+        {"ny": -1},
+        {"nx": 2.5},
+        {"dx": 0.0},
+        {"dy": float("nan")},
+        {"dtype": torch.float16},
+    ],
+)
+def test_grid_rejects_invalid_geometry_and_dtype(kwargs):
+    defaults = {"nx": 4, "ny": 3, "dx": 0.1, "dy": 0.2}
+    defaults.update(kwargs)
+
+    with pytest.raises(ValueError):
+        Grid(**defaults)

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.core.source import PlaneWave
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.elements.mask import (
+    ArbitraryAperture,
+    CircularAperture,
+    Piston,
+    Step,
+    TipTilt,
+)
+
+
+@pytest.fixture
+def optical_state():
+    grid = Grid(7, 5, 0.1, 0.2, dtype=torch.float64)
+    spectrum = Spectrum(0, Band(1e-6, 0.0, 1e8), 1, dtype=torch.float64)
+    field = PlaneWave(spectrum).generate_field(grid)
+    return grid, spectrum, field
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda grid: CircularAperture(grid, radius=0.25),
+        lambda grid: Piston(grid, piston=100e-9),
+        lambda grid: Step(grid, piston=100e-9),
+        lambda grid: TipTilt(grid, tip=10e-9, tilt=-20e-9),
+    ],
+)
+def test_standard_masks_preserve_field_contract(optical_state, factory):
+    grid, _, field = optical_state
+    mask = factory(grid)
+
+    output = mask.apply(field)
+
+    assert output.grid is field.grid
+    assert output.spectrum is field.spectrum
+    assert output.complex_amplitude.shape == field.complex_amplitude.shape
+    assert output.complex_amplitude.dtype == torch.complex128
+    assert output.complex_amplitude.device == grid.device
+    assert mask.opd.shape == grid.shape
+    assert mask.opd.dtype == grid.dtype
+
+
+def test_circular_aperture_blocks_pixels_outside_radius(optical_state):
+    grid, spectrum, _ = optical_state
+    aperture = CircularAperture(grid, radius=0.15)
+
+    aperture.build(spectrum)
+
+    x, y = grid.meshgrid()
+    assert torch.equal(aperture.transmission, x.square() + y.square() <= 0.15**2)
+
+
+def test_arbitrary_aperture_rejects_wrong_shape(optical_state):
+    grid, spectrum, _ = optical_state
+    aperture = ArbitraryAperture(grid, torch.ones(7, 5))
+
+    with pytest.raises(ValueError, match="does not match grid shape"):
+        aperture.build(spectrum)
+
+
+def test_mask_rejects_field_on_different_grid(optical_state):
+    grid, _, _ = optical_state
+    other_grid = Grid(7, 5, 0.2, 0.2, dtype=torch.float64)
+    field = PlaneWave(Spectrum(0, Band(1e-6, 0.0, 1e8), 1)).generate_field(
+        Grid(7, 5, 0.1, 0.2)
+    )
+
+    with pytest.raises(ValueError, match="grid must match"):
+        CircularAperture(other_grid, radius=0.2).apply(field)

--- a/tests/test_propagators.py
+++ b/tests/test_propagators.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.core.source import PlaneWave
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.propagator import IdentityPropagator, MFTPropagator
+
+
+def make_field(grid):
+    spectrum = Spectrum(
+        0, Band(1e-6, 0.1e-6, 1e8), 2, device=grid.device, dtype=grid.dtype
+    )
+    return PlaneWave(spectrum).generate_field(grid)
+
+
+def test_identity_propagator_returns_the_same_field_object():
+    grid = Grid(7, 5, 0.1, 0.2)
+    field = make_field(grid)
+
+    assert IdentityPropagator(grid).apply(field) is field
+
+
+@pytest.mark.parametrize(
+    "dtype, complex_dtype",
+    [(torch.float32, torch.complex64), (torch.float64, torch.complex128)],
+)
+def test_mft_transforms_shape_and_preserves_tensor_contract(dtype, complex_dtype):
+    input_grid = Grid(7, 5, 0.1, 0.2, dtype=dtype)
+    output_grid = Grid(8, 4, 1e-6, 2e-6, dtype=dtype)
+    field = make_field(input_grid)
+
+    output = MFTPropagator(2.0, output_grid).apply(field)
+
+    assert output.grid is output_grid
+    assert output.spectrum is field.spectrum
+    assert output.complex_amplitude.shape == (2, 4, 8)
+    assert output.complex_amplitude.dtype == complex_dtype
+
+
+def test_mft_rejects_mixed_grid_precision():
+    input_grid = Grid(7, 5, 0.1, 0.2, dtype=torch.float32)
+    output_grid = Grid(8, 4, 1e-6, 2e-6, dtype=torch.float64)
+
+    with pytest.raises(ValueError, match="same dtype"):
+        MFTPropagator(2.0, output_grid).apply(make_field(input_grid))


### PR DESCRIPTION
## Summary

- add dedicated Grid contract and validation tests
- add standard-mask shape, dtype, transmission, and grid-compatibility tests
- add identity and MFT propagator contract tests
- exercise both float32/complex64 and float64/complex128 propagation
- document how to run the complete suite and what it covers

These complement the existing Field, Spectrum, source, detector, DM, atmosphere/NCPA, InteractionMatrix, configuration, rectangular-grid, and CPU/CUDA tests.

## Validation

```
190 passed, 3 skipped
```

The skipped cases are conditional tests whose optional runtime requirements are unavailable in the test environment.

Closes #20