### PR TITLE
Make HARMONI residual FITS loading explicit and robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,10 @@ For example, when HARMONI residual phase-screen data are available, the ELT
 pupil support is exposed directly by the residual object:
 
 ```python
-atm_res = HarmoniResiduals(grid=pupil_grid)
+atm_res = HarmoniResiduals(
+    grid=pupil_grid,
+    dataset_path="/path/to/harmoni_residuals",
+)
 
 pupil_mask = atm_res.pupil.to(torch.float32)
 
@@ -301,7 +304,9 @@ elt_pupil = ArbitraryAperture(
 ```
 
 > [!IMPORTANT]
-> Examples based on `HarmoniResiduals` require the corresponding residual phase-screen FITS data to be available locally.
+> Examples based on `HarmoniResiduals` require the corresponding residual
+> phase-screen FITS data to be available locally. The dataset path is always
+> explicit; see the [HARMONI dataset format](docs/harmoni_data.md).
 
 ---
 

--- a/docs/harmoni_data.md
+++ b/docs/harmoni_data.md
@@ -1,0 +1,45 @@
+# HARMONI residual dataset format
+
+`HarmoniResiduals` loads a directory of FITS files in deterministic filename
+order. The directory is supplied explicitly:
+
+```python
+residuals = HarmoniResiduals(
+    grid=pupil_grid,
+    dataset_path="/path/to/harmoni_residuals",
+)
+```
+
+## Default FITS structure
+
+By default, each primary HDU contains a floating-point array shaped
+`(n_products, n_screens, ny, nx)`. Product index 1 contains residual optical
+path difference. Values are interpreted as metres of OPD. Files, HDUs, and
+arrays that do not follow the declared structure are rejected with a
+`HarmoniDatasetError` subclass naming the offending path.
+
+The defaults reproduce the historical orientation by rotating each screen by
+one quarter turn. Set `rotate_quarter_turns=0` if the stored orientation already
+matches the Fiatlux grid. The transformed spatial shape must equal
+`(grid.ny, grid.nx)`.
+
+For FITS files storing a direct cube shaped `(n_screens, ny, nx)`, pass
+`opd_plane_index=None`. A dataset requiring unit conversion can use an explicit
+factor such as `opd_scale=1e-9` for nanometres to metres. The default scale is
+1, so no undocumented physical conversion is applied.
+
+## Pupil support and screen order
+
+Pass an authoritative boolean or binary support as `pupil=` whenever the
+dataset supplies one. Otherwise Fiatlux derives a compatibility support from
+the union of non-zero pixels over the complete loaded cube.
+
+Screens are visited without replacement in a seeded permutation and then
+cycled. Use `seed=` for repeatable shuffled order or `shuffle=False` for strict
+file-and-frame order.
+
+Install FITS support with:
+
+```bash
+python -m pip install 'fiatlux[fits]'
+```

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -63,6 +63,9 @@ from .optics.elements.mask import (
     TipTilt,
     Piston,
     HarmoniResiduals,
+    HarmoniDatasetError,
+    HarmoniDatasetNotFoundError,
+    InvalidHarmoniDatasetError,
 )
 
 # =========================
@@ -121,6 +124,9 @@ __all__ = [
     "TipTilt",
     "Piston",
     "HarmoniResiduals",
+    "HarmoniDatasetError",
+    "HarmoniDatasetNotFoundError",
+    "InvalidHarmoniDatasetError",
     # Config
     "from_json",
     "SimulationSetup",

--- a/fiatlux/optics/elements/mask.py
+++ b/fiatlux/optics/elements/mask.py
@@ -12,7 +12,7 @@ from fiatlux.optics.atmosphere import AtmosphereModel, NCPAModel
 
 from fiatlux.config.registry import register_type
 
-import os
+from pathlib import Path
 
 from itertools import cycle
 
@@ -341,6 +341,18 @@ class Random(Mask):
         self.opd = self.amplitude * torch.randn(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
 
+class HarmoniDatasetError(RuntimeError):
+    """Base exception for an unusable HARMONI residual dataset."""
+
+
+class HarmoniDatasetNotFoundError(HarmoniDatasetError, FileNotFoundError):
+    """The configured HARMONI dataset directory cannot be read."""
+
+
+class InvalidHarmoniDatasetError(HarmoniDatasetError, ValueError):
+    """A HARMONI dataset exists but does not satisfy the documented format."""
+
+
 class HarmoniResiduals(Mask):
     """Sequence of HARMONI residual OPD screens and its pupil support.
 
@@ -351,18 +363,40 @@ class HarmoniResiduals(Mask):
     ``support`` is an alias for ``pupil``.
     """
 
-    def __init__(self, grid: Grid, pupil: torch.Tensor | None = None):
+    def __init__(
+        self,
+        grid: Grid,
+        dataset_path: str | Path,
+        pupil: torch.Tensor | None = None,
+        *,
+        hdu_index: int = 0,
+        opd_plane_index: int | None = 1,
+        opd_scale: float = 1.0,
+        rotate_quarter_turns: int = 1,
+        shuffle: bool = True,
+        seed: int = 0,
+    ):
         self.grid = grid
+        self.dataset_path = Path(dataset_path).expanduser()
+        self.hdu_index = hdu_index
+        self.opd_plane_index = opd_plane_index
+        self.opd_scale = float(opd_scale)
+        self.rotate_quarter_turns = rotate_quarter_turns
+        self.files = self._dataset_files(self.dataset_path)
         self.load_datacube(
-            path="/Users/janinpop/Documents/code/use_fiatlux/data/harmoni_residuals"
+            self.files,
+            hdu_index=hdu_index,
+            opd_plane_index=opd_plane_index,
+            opd_scale=self.opd_scale,
+            rotate_quarter_turns=rotate_quarter_turns,
         )
         self.pupil = self._prepare_pupil(pupil)
 
-        r = 1009
-        N = len(self.datacube)
-        idx = torch.arange(N).repeat(r)
-        idx = idx[torch.randperm(idx.numel())]
-        self.iterator = iter(cycle(idx.tolist()))
+        indices = torch.arange(len(self.datacube))
+        if shuffle:
+            generator = torch.Generator().manual_seed(seed)
+            indices = indices[torch.randperm(len(indices), generator=generator)]
+        self.iterator = iter(cycle(indices.tolist()))
 
         super().__init__(grid=grid, recompute=True)
 
@@ -393,7 +427,34 @@ class HarmoniResiduals(Mask):
         """Alias for the public boolean :attr:`pupil` mask."""
         return self.pupil
 
-    def load_datacube(self, path: str) -> None:
+    @staticmethod
+    def _dataset_files(path: Path) -> list[Path]:
+        if not path.exists():
+            raise HarmoniDatasetNotFoundError(
+                f"HARMONI dataset directory does not exist: {path}"
+            )
+        if not path.is_dir():
+            raise HarmoniDatasetNotFoundError(
+                f"HARMONI dataset path is not a directory: {path}"
+            )
+        files = sorted(
+            item for item in path.iterdir() if item.is_file() and item.suffix.lower() == ".fits"
+        )
+        if not files:
+            raise InvalidHarmoniDatasetError(
+                f"HARMONI dataset directory contains no FITS files: {path}"
+            )
+        return files
+
+    def load_datacube(
+        self,
+        files: list[Path],
+        *,
+        hdu_index: int,
+        opd_plane_index: int | None,
+        opd_scale: float,
+        rotate_quarter_turns: int,
+    ) -> None:
         try:
             from astropy.io import fits
         except ImportError as error:
@@ -401,20 +462,73 @@ class HarmoniResiduals(Mask):
                 "HARMONI FITS data require Astropy; install it with "
                 "`python -m pip install 'fiatlux[fits]'`."
             ) from error
+        if not isinstance(hdu_index, int) or isinstance(hdu_index, bool) or hdu_index < 0:
+            raise ValueError("hdu_index must be a non-negative integer.")
+        if opd_plane_index is not None and (
+            not isinstance(opd_plane_index, int)
+            or isinstance(opd_plane_index, bool)
+            or opd_plane_index < 0
+        ):
+            raise ValueError("opd_plane_index must be None or a non-negative integer.")
+        if not torch.isfinite(torch.tensor(opd_scale)) or opd_scale == 0:
+            raise ValueError("opd_scale must be finite and non-zero.")
+        if not isinstance(rotate_quarter_turns, int) or isinstance(
+            rotate_quarter_turns, bool
+        ):
+            raise ValueError("rotate_quarter_turns must be an integer.")
+
         datacube = []
-        for file in os.listdir(path):
-            if file.endswith(".fits"):
-                hdul = fits.open(os.path.join(path, file))
-                arr = hdul[0].data[1, ...]
-                datacube.append(
-                    torch.rot90(
-                        torch.tensor(
-                            arr.astype(arr.dtype.newbyteorder("="), copy=True)
-                        ),
-                        dims=[1, 2],
-                    ).to(torch.float)
-                    / 2
+        for file in files:
+            with fits.open(file, memmap=False) as hdul:
+                if hdu_index >= len(hdul):
+                    raise InvalidHarmoniDatasetError(
+                        f"{file}: missing HDU index {hdu_index}."
+                    )
+                data = hdul[hdu_index].data
+                if data is None:
+                    raise InvalidHarmoniDatasetError(
+                        f"{file}: HDU {hdu_index} contains no data."
+                    )
+                if data.dtype.kind != "f":
+                    raise InvalidHarmoniDatasetError(
+                        f"{file}: residual OPD data must have a floating dtype; "
+                        f"got {data.dtype}."
+                    )
+                if opd_plane_index is None:
+                    if data.ndim != 3:
+                        raise InvalidHarmoniDatasetError(
+                            f"{file}: expected shape (n_screens, ny, nx) when "
+                            f"opd_plane_index=None; got {data.shape}."
+                        )
+                    selected = data
+                else:
+                    if data.ndim != 4 or opd_plane_index >= data.shape[0]:
+                        raise InvalidHarmoniDatasetError(
+                            f"{file}: expected shape (n_products, n_screens, ny, nx) "
+                            f"containing product {opd_plane_index}; got {data.shape}."
+                        )
+                    selected = data[opd_plane_index]
+
+                if selected.shape[0] < 1:
+                    raise InvalidHarmoniDatasetError(
+                        f"{file}: residual OPD cube contains no screens."
+                    )
+
+                native = selected.astype(selected.dtype.newbyteorder("="), copy=True)
+                cube = torch.from_numpy(native).to(dtype=self.grid.dtype)
+                cube = torch.rot90(
+                    cube, k=rotate_quarter_turns % 4, dims=(-2, -1)
                 )
+                if tuple(cube.shape[-2:]) != self.grid.shape:
+                    raise InvalidHarmoniDatasetError(
+                        f"{file}: transformed residual shape {tuple(cube.shape[-2:])} "
+                        f"does not match grid shape {self.grid.shape}."
+                    )
+                if not torch.isfinite(cube).all():
+                    raise InvalidHarmoniDatasetError(
+                        f"{file}: residual OPD data contain NaN or infinite values."
+                    )
+                datacube.append(cube * opd_scale)
         self.datacube = torch.cat(datacube, dim=0)
 
     def _build_transmission(self) -> None:

--- a/tests/test_harmoni_residuals.py
+++ b/tests/test_harmoni_residuals.py
@@ -1,47 +1,110 @@
+import numpy as np
 import pytest
 import torch
 
 from fiatlux.core.grid import Grid
-from fiatlux.optics.elements.mask import HarmoniResiduals
+from fiatlux.optics.elements.mask import (
+    HarmoniDatasetNotFoundError,
+    HarmoniResiduals,
+    InvalidHarmoniDatasetError,
+)
 
 
-def make_residuals(monkeypatch, datacube, pupil=None):
-    def load_datacube(instance, path):
-        instance.datacube = datacube.clone()
-
-    monkeypatch.setattr(HarmoniResiduals, "load_datacube", load_datacube)
-    grid = Grid(nx=datacube.shape[-1], ny=datacube.shape[-2], dx=0.1, dy=0.1)
-    return HarmoniResiduals(grid, pupil=pupil)
+fits = pytest.importorskip("astropy.io.fits")
 
 
-def test_public_pupil_uses_support_across_the_complete_cube(monkeypatch):
-    datacube = torch.zeros((2, 3, 4))
-    datacube[0, 0, 0] = 1.0
-    datacube[1, 1, 2] = 1.0
+def write_dataset_file(path, values, *, dtype=np.float32):
+    data = np.zeros((2, len(values), 2, 3), dtype=dtype)
+    data[1] = np.asarray(values, dtype=dtype)[:, None, None]
+    fits.PrimaryHDU(data).writeto(path)
 
-    residuals = make_residuals(monkeypatch, datacube)
 
-    assert residuals.pupil.dtype == torch.bool
-    assert residuals.pupil[0, 0]
-    assert residuals.pupil[1, 2]
+def make_grid():
+    return Grid(nx=3, ny=2, dx=0.1, dy=0.1)
+
+
+def test_valid_fits_files_are_sorted_scaled_and_sampled_in_order(tmp_path):
+    write_dataset_file(tmp_path / "b.fits", [2.0])
+    write_dataset_file(tmp_path / "a.fits", [1.0])
+
+    residuals = HarmoniResiduals(
+        make_grid(),
+        dataset_path=tmp_path,
+        opd_scale=1e-9,
+        rotate_quarter_turns=0,
+        shuffle=False,
+    )
+
+    assert [path.name for path in residuals.files] == ["a.fits", "b.fits"]
+    torch.testing.assert_close(
+        residuals.datacube[:, 0, 0], torch.tensor([1e-9, 2e-9])
+    )
+    residuals._build_opd()
+    torch.testing.assert_close(residuals.opd, residuals.datacube[0])
+    residuals._build_opd()
+    torch.testing.assert_close(residuals.opd, residuals.datacube[1])
+
+
+def test_public_pupil_can_be_authoritative_when_opd_is_zero(tmp_path):
+    write_dataset_file(tmp_path / "screens.fits", [0.0])
+    pupil = torch.zeros((2, 3), dtype=torch.bool)
+    pupil[1, 1] = True
+
+    residuals = HarmoniResiduals(
+        make_grid(), tmp_path, pupil=pupil, rotate_quarter_turns=0
+    )
+
+    assert residuals.pupil[1, 1]
     assert residuals.support is residuals.pupil
 
 
-def test_explicit_pupil_is_independent_of_zero_opd_values(monkeypatch):
-    datacube = torch.zeros((2, 3, 4))
-    pupil = torch.zeros((3, 4), dtype=torch.bool)
-    pupil[1, 1] = True
+def test_shuffle_order_is_reproducible_for_a_seed(tmp_path):
+    write_dataset_file(tmp_path / "screens.fits", [1.0, 2.0, 3.0, 4.0])
+    kwargs = dict(dataset_path=tmp_path, rotate_quarter_turns=0, seed=17)
+    first = HarmoniResiduals(make_grid(), **kwargs)
+    second = HarmoniResiduals(make_grid(), **kwargs)
 
-    residuals = make_residuals(monkeypatch, datacube, pupil=pupil)
+    first_order = [next(first.iterator) for _ in range(4)]
+    second_order = [next(second.iterator) for _ in range(4)]
 
-    assert residuals.pupil[1, 1]
-    assert torch.count_nonzero(residuals.pupil) == 1
+    assert first_order == second_order
+    assert sorted(first_order) == list(range(4))
 
 
-def test_pupil_shape_and_binary_values_are_validated(monkeypatch):
-    datacube = torch.zeros((2, 3, 4))
+def test_missing_non_directory_and_empty_paths_have_actionable_errors(tmp_path):
+    with pytest.raises(HarmoniDatasetNotFoundError, match="does not exist"):
+        HarmoniResiduals(make_grid(), tmp_path / "missing")
 
-    with pytest.raises(ValueError, match="must have grid shape"):
-        make_residuals(monkeypatch, datacube, pupil=torch.ones(4, 3))
-    with pytest.raises(ValueError, match="only 0 and 1"):
-        make_residuals(monkeypatch, datacube, pupil=torch.full((3, 4), 0.5))
+    file_path = tmp_path / "not-a-directory"
+    file_path.write_text("x")
+    with pytest.raises(HarmoniDatasetNotFoundError, match="not a directory"):
+        HarmoniResiduals(make_grid(), file_path)
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(InvalidHarmoniDatasetError, match="contains no FITS"):
+        HarmoniResiduals(make_grid(), empty)
+
+
+@pytest.mark.parametrize(
+    "data, message",
+    [
+        (np.zeros((2, 2, 3), dtype=np.float32), "expected shape"),
+        (np.zeros((2, 1, 4, 3), dtype=np.float32), "does not match grid shape"),
+        (np.zeros((2, 1, 2, 3), dtype=np.int16), "floating dtype"),
+        (np.full((2, 1, 2, 3), np.nan, dtype=np.float32), "NaN or infinite"),
+        (np.zeros((2, 0, 2, 3), dtype=np.float32), "contains no screens"),
+    ],
+)
+def test_malformed_fits_data_are_rejected(tmp_path, data, message):
+    fits.PrimaryHDU(data).writeto(tmp_path / "bad.fits")
+
+    with pytest.raises(InvalidHarmoniDatasetError, match=message):
+        HarmoniResiduals(make_grid(), tmp_path, rotate_quarter_turns=0)
+
+
+def test_missing_hdu_is_rejected(tmp_path):
+    write_dataset_file(tmp_path / "screens.fits", [1.0])
+
+    with pytest.raises(InvalidHarmoniDatasetError, match="missing HDU index 2"):
+        HarmoniResiduals(make_grid(), tmp_path, hdu_index=2)

--- a/tutorials/06_elt_pupil_from_harmoni.ipynb
+++ b/tutorials/06_elt_pupil_from_harmoni.ipynb
@@ -12,7 +12,7 @@
         "The logic is:\n",
         "\n",
         "1. build the ELT pupil sampling grid,\n",
-        "2. instantiate `HarmoniResiduals(grid=pupil_grid)`,\n",
+        "2. instantiate `HarmoniResiduals` with an explicit dataset path,\n",
         "3. read the public pupil support exposed by the residual object,\n",
         "4. use that mask inside `ArbitraryAperture`,\n",
         "5. propagate to the focal plane and display the PSF.\n",
@@ -20,7 +20,7 @@
         "This matches the usage pattern:\n",
         "\n",
         "```python\n",
-        "atm_res = HarmoniResiduals(grid=pupil_grid)\n",
+        "atm_res = HarmoniResiduals(grid=pupil_grid, dataset_path=dataset_path)\n",
         "pupil_mask = atm_res.pupil.to(torch.float32)\n",
         "",
         "```\n",
@@ -41,7 +41,7 @@
         "> `HarmoniResiduals.pupil` is a dedicated boolean support mask:\n",
         ">\n",
         "> ```python\n",
-        "> atm_res = HarmoniResiduals(grid=pupil_grid)\n",
+        "> atm_res = HarmoniResiduals(grid=pupil_grid, dataset_path=dataset_path)\n",
         "> pupil_mask = (atm_res.datacube[0] != 0).to(torch.float32)\n",
         "> ```\n",
         ">\n",
@@ -119,7 +119,7 @@
       "source": [
         "## Instantiate `HarmoniResiduals`\n",
         "\n",
-        "This object contains residual phase screens sampled on the same pupil grid."
+        "This object contains residual phase screens sampled on the same pupil grid. The path is explicit so the notebook never depends on a developer machine."
       ]
     },
     {
@@ -136,7 +136,7 @@
         }
       ],
       "source": [
-        "atm_res = HarmoniResiduals(grid=pupil_grid)\n",
+        "from pathlib import Path\n\ndataset_path = Path(\"/path/to/harmoni_residuals\")\natm_res = HarmoniResiduals(grid=pupil_grid, dataset_path=dataset_path)\n",
         "\n",
         "print(\"Residual datacube shape:\", atm_res.datacube.shape)"
       ]


### PR DESCRIPTION
## Summary
- require an explicit HARMONI dataset path and remove the machine-specific path
- sort FITS filenames deterministically and close every file with a context manager
- validate paths, HDUs, floating dtype, array layout, non-empty cubes, finite values and grid shape
- add dedicated missing/invalid dataset exceptions
- document OPD units, product selection, orientation and explicit scaling
- replace the unexplained repetition count with seeded without-replacement ordering
- update the README and tutorial for the new constructor
- test loading with synthetic FITS datasets

## Validation
- HARMONI loader tests: `10 passed`
- complete suite: `215 passed, 3 skipped`
- tutorial notebook is valid JSON

Closes #26