### PR TITLE
Stabilize public exports and optional dependency loading

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,7 +19,17 @@ jobs:
       - name: Install core package
         run: python -m pip install .
       - name: Test isolated core import
-        run: python -I -c "import fiatlux; print(fiatlux.__version__)"
+        run: |
+          python -I - <<'PY'
+          import sys
+          import fiatlux
+
+          optional_modules = {"astropy", "matplotlib", "scipy", "torchvision"}
+          loaded = optional_modules.intersection(sys.modules)
+          assert not loaded, f"unexpected optional imports: {sorted(loaded)}"
+          assert all(hasattr(fiatlux, name) for name in fiatlux.__all__)
+          print(fiatlux.__version__)
+          PY
       - name: Inspect installed metadata
         run: |
           python - <<'PY'

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -1,5 +1,5 @@
 from .adc import ADCDispersionModel
-from .atmosphere import AtmosphereModel
+from .atmosphere import AtmosphereModel, KolmogorovAtmosphereModel, NCPAModel
 from .detector import Detector
 from .propagator import Propagator
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import subprocess
+import sys
+
+import fiatlux
+import fiatlux.optics as optics
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_top_level_public_exports_are_importable():
+    for name in fiatlux.__all__:
+        assert getattr(fiatlux, name) is not None
+
+
+def test_optics_public_exports_are_importable():
+    for name in optics.__all__:
+        assert getattr(optics, name) is not None
+
+
+def test_core_import_does_not_load_optional_dependencies():
+    script = """
+import sys
+import fiatlux
+
+optional_modules = {"astropy", "matplotlib", "scipy", "torchvision"}
+loaded = optional_modules.intersection(sys.modules)
+assert not loaded, f"optional dependencies loaded by import fiatlux: {sorted(loaded)}"
+"""
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+    )


### PR DESCRIPTION
## Summary

- fix the `fiatlux.optics.__all__` contract by importing every advertised atmosphere model
- verify every top-level and optics public export is actually accessible
- ensure `import fiatlux` does not load Astropy, Matplotlib, SciPy, or Torchvision
- enforce the same checks in the clean-install CI job

The core dependency split and lazy Astropy import were introduced by the recent packaging and HARMONI loader work. This PR adds the missing public-API fix and regression coverage that make those guarantees explicit.

## Validation

- `218 passed, 3 skipped`
- clean-install CI checks Python 3.10 and 3.12 with only core dependencies

Closes #34