### PR TITLE
Make stochastic components independently reproducible

### DIFF
--- a/fiatlux/optics/atmosphere.py
+++ b/fiatlux/optics/atmosphere.py
@@ -24,9 +24,10 @@ import math
 import torch
 
 from fiatlux.core.grid import Grid
+from fiatlux.utils.random import RandomGeneratorMixin
 
 
-class AtmosphereModel(ABC):
+class AtmosphereModel(RandomGeneratorMixin, ABC):
     """Base class for phase-screen statistics on a fixed spatial grid."""
 
     def __init__(
@@ -35,6 +36,7 @@ class AtmosphereModel(ABC):
         *,
         reference_wavelength: float,
         seed: int | None = None,
+        generator: torch.Generator | None = None,
         dtype: torch.dtype | None = None,
     ) -> None:
         if grid.nx < 2 or grid.ny < 2:
@@ -50,11 +52,11 @@ class AtmosphereModel(ABC):
         self.grid = grid
         self.reference_wavelength = float(reference_wavelength)
         self.dtype = dtype
-        self.generator = torch.Generator(device=grid.device)
-        if seed is None:
-            self.generator.seed()
-        else:
-            self.generator.manual_seed(seed)
+        self._configure_generator(
+            grid.device,
+            seed=seed,
+            generator=generator,
+        )
 
         # PSD arrays use native, unshifted torch.fft ordering.
         self.phase_psd = self.compute_phase_psd()
@@ -166,6 +168,7 @@ class KolmogorovAtmosphereModel(AtmosphereModel):
         *,
         outer_scale: float | None = None,
         seed: int | None = None,
+        generator: torch.Generator | None = None,
         dtype: torch.dtype | None = None,
     ) -> None:
         if r0 <= 0:
@@ -179,6 +182,7 @@ class KolmogorovAtmosphereModel(AtmosphereModel):
             grid,
             reference_wavelength=reference_wavelength,
             seed=seed,
+            generator=generator,
             dtype=dtype,
         )
 
@@ -198,7 +202,7 @@ class KolmogorovAtmosphereModel(AtmosphereModel):
         return 0.023 * self.r0 ** (-5.0 / 3.0) * radial_term
 
 
-class NCPAModel:
+class NCPAModel(RandomGeneratorMixin):
     """Stationary isotropic power-law model for instrumental NCPA.
 
     Unlike atmospheric phase statistics, NCPA are defined directly as an
@@ -236,6 +240,7 @@ class NCPAModel:
         spectral_index: float = 3.0,
         outer_scale: float | None = None,
         seed: int | None = None,
+        generator: torch.Generator | None = None,
         dtype: torch.dtype | None = None,
     ) -> None:
         if grid.nx < 2 or grid.ny < 2:
@@ -257,11 +262,11 @@ class NCPAModel:
         self.spectral_index = float(spectral_index)
         self.outer_scale = None if outer_scale is None else float(outer_scale)
         self.dtype = dtype
-        self.generator = torch.Generator(device=grid.device)
-        if seed is None:
-            self.generator.seed()
-        else:
-            self.generator.manual_seed(seed)
+        self._configure_generator(
+            grid.device,
+            seed=seed,
+            generator=generator,
+        )
 
         self.opd_psd = self.compute_opd_psd()
 

--- a/fiatlux/optics/detector.py
+++ b/fiatlux/optics/detector.py
@@ -3,9 +3,10 @@ import torch
 from fiatlux.core.grid import Grid
 from fiatlux.core.field import Field
 from fiatlux.optics.elements.base import validate_field_grid
+from fiatlux.utils.random import RandomGeneratorMixin
 
 
-class Detector:
+class Detector(RandomGeneratorMixin):
     def __init__(
         self,
         grid: Grid,
@@ -18,7 +19,8 @@ class Detector:
         bitdepth: int = 16,
         digitize: bool = False,
         sensitivity: float = 1.0,
-        random_seed: int = 0,
+        random_seed: int | None = None,
+        generator: torch.Generator | None = None,
         name: str = "",
     ):
         if exposure_time < 0:
@@ -46,7 +48,11 @@ class Detector:
         self.digitize = digitize
         self.sensitivity = sensitivity
         self.random_seed = random_seed
-        self.generator = torch.Generator(device=grid.device).manual_seed(random_seed)
+        self._configure_generator(
+            grid.device,
+            seed=random_seed,
+            generator=generator,
+        )
         self.name = name
         self.image_buffer = None
 

--- a/fiatlux/optics/elements/mask.py
+++ b/fiatlux/optics/elements/mask.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 from itertools import cycle
 
+from fiatlux.utils.random import RandomGeneratorMixin
+
 @dataclass
 class Mask(OpticalElement, ABC):
     """
@@ -278,16 +280,26 @@ class ADC(Mask):
         )
 
 
-class Atmosphere(Mask):
+class Atmosphere(RandomGeneratorMixin, Mask):
     def __init__(
         self,
         grid: Grid,
         atmosphere_model: AtmosphereModel,
         recompute: bool = True,
         remove_piston: bool = True,
+        seed: int | None = None,
+        generator: torch.Generator | None = None,
     ):
         self.atmosphere_model = atmosphere_model
         self.remove_piston = remove_piston
+        if seed is None and generator is None:
+            self.generator = atmosphere_model.generator
+        else:
+            self._configure_generator(
+                grid.device,
+                seed=seed,
+                generator=generator,
+            )
         super().__init__(grid=grid, recompute=recompute)
 
     def _build_transmission(self) -> None:
@@ -299,18 +311,29 @@ class Atmosphere(Mask):
 
     def _build_opd(self) -> None:
         self.opd = self.atmosphere_model.sample_opd(
+            generator=self.generator,
             remove_piston=self.remove_piston
         )
 
 
-class NCPA(Mask):
+class NCPA(RandomGeneratorMixin, Mask):
     def __init__(
         self,
         grid: Grid,
         ncpa_model: NCPAModel,
         recompute: bool = True,
+        seed: int | None = None,
+        generator: torch.Generator | None = None,
     ):
         self.ncpa_model = ncpa_model
+        if seed is None and generator is None:
+            self.generator = ncpa_model.generator
+        else:
+            self._configure_generator(
+                grid.device,
+                seed=seed,
+                generator=generator,
+            )
         super().__init__(grid=grid, recompute=recompute)
 
     def _build_transmission(self) -> None:
@@ -321,24 +344,36 @@ class NCPA(Mask):
         )
 
     def _build_opd(self) -> None:
-        self.opd = self.ncpa_model.sample_opd()
+        self.opd = self.ncpa_model.sample_opd(generator=self.generator)
 
 
-class Random(Mask):
+class Random(RandomGeneratorMixin, Mask):
     def __init__(
         self,
         grid: Grid,
         amplitude: float,
         recompute: bool = True,
+        seed: int | None = None,
+        generator: torch.Generator | None = None,
     ):
         self.amplitude = amplitude
+        self._configure_generator(
+            grid.device,
+            seed=seed,
+            generator=generator,
+        )
         super().__init__(grid=grid, recompute=recompute)
 
     def _build_transmission(self) -> None:
         self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
-        self.opd = self.amplitude * torch.randn(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
+        self.opd = self.amplitude * torch.randn(
+            self.grid.shape,
+            device=self.grid.device,
+            dtype=self.grid.dtype,
+            generator=self.generator,
+        )
 
 
 class HarmoniDatasetError(RuntimeError):
@@ -353,7 +388,7 @@ class InvalidHarmoniDatasetError(HarmoniDatasetError, ValueError):
     """A HARMONI dataset exists but does not satisfy the documented format."""
 
 
-class HarmoniResiduals(Mask):
+class HarmoniResiduals(RandomGeneratorMixin, Mask):
     """Sequence of HARMONI residual OPD screens and its pupil support.
 
     ``pupil`` is a boolean transmission mask independent from the individual
@@ -374,7 +409,8 @@ class HarmoniResiduals(Mask):
         opd_scale: float = 1.0,
         rotate_quarter_turns: int = 1,
         shuffle: bool = True,
-        seed: int = 0,
+        seed: int | None = None,
+        generator: torch.Generator | None = None,
     ):
         self.grid = grid
         self.dataset_path = Path(dataset_path).expanduser()
@@ -392,11 +428,18 @@ class HarmoniResiduals(Mask):
         )
         self.pupil = self._prepare_pupil(pupil)
 
+        self._configure_generator(
+            "cpu",
+            seed=seed,
+            generator=generator,
+        )
         indices = torch.arange(len(self.datacube))
         if shuffle:
-            generator = torch.Generator().manual_seed(seed)
-            indices = indices[torch.randperm(len(indices), generator=generator)]
-        self.iterator = iter(cycle(indices.tolist()))
+            indices = indices[
+                torch.randperm(len(indices), generator=self.generator)
+            ]
+        self._indices = indices.tolist()
+        self.iterator = iter(cycle(self._indices))
 
         super().__init__(grid=grid, recompute=True)
 
@@ -535,4 +578,7 @@ class HarmoniResiduals(Mask):
         self.transmission = torch.ones(self.grid.shape, device=self.grid.device, dtype=self.grid.dtype)
 
     def _build_opd(self) -> None:
-        self.opd = self.datacube[next(self.iterator), ...].to(device=self.grid.device, dtype=self.grid.dtype)
+        self.opd = self.datacube[next(self.iterator), ...].to(
+            device=self.grid.device,
+            dtype=self.grid.dtype,
+        )

--- a/fiatlux/utils/random.py
+++ b/fiatlux/utils/random.py
@@ -1,0 +1,55 @@
+"""Private random-number generators for reproducible simulation components."""
+
+from __future__ import annotations
+
+import torch
+
+
+class RandomGeneratorMixin:
+    """Own a device-compatible :class:`torch.Generator`.
+
+    Generator state is part of the Python object, so `copy.deepcopy`,
+    `pickle`, and `torch.save` preserve the point reached in the random
+    sequence. The explicit state methods also support lightweight checkpoints.
+    """
+
+    generator: torch.Generator
+
+    def _configure_generator(
+        self,
+        device: torch.device | str,
+        *,
+        seed: int | None,
+        generator: torch.Generator | None,
+    ) -> None:
+        device = torch.device(device)
+        if seed is not None and generator is not None:
+            raise ValueError("Pass either seed or generator, not both.")
+        if seed is not None and (
+            not isinstance(seed, int) or isinstance(seed, bool)
+        ):
+            raise TypeError("seed must be an integer or None.")
+        if generator is not None:
+            if not isinstance(generator, torch.Generator):
+                raise TypeError("generator must be a torch.Generator or None.")
+            if torch.device(generator.device) != device:
+                raise ValueError(
+                    f"generator device {generator.device} does not match "
+                    f"simulation device {device}."
+                )
+            self.generator = generator
+            return
+
+        self.generator = torch.Generator(device=device)
+        if seed is None:
+            self.generator.seed()
+        else:
+            self.generator.manual_seed(seed)
+
+    def get_rng_state(self) -> torch.Tensor:
+        """Return an independent CPU snapshot of the generator state."""
+        return self.generator.get_state().clone()
+
+    def set_rng_state(self, state: torch.Tensor) -> None:
+        """Resume the generator from a state returned by :meth:`get_rng_state`."""
+        self.generator.set_state(torch.as_tensor(state, device="cpu").clone())

--- a/tests/test_harmoni_residuals.py
+++ b/tests/test_harmoni_residuals.py
@@ -71,6 +71,29 @@ def test_shuffle_order_is_reproducible_for_a_seed(tmp_path):
     assert sorted(first_order) == list(range(4))
 
 
+def test_shuffle_accepts_an_external_generator(tmp_path):
+    write_dataset_file(tmp_path / "screens.fits", [1.0, 2.0, 3.0, 4.0])
+    first_generator = torch.Generator().manual_seed(29)
+    second_generator = torch.Generator().manual_seed(29)
+
+    first = HarmoniResiduals(
+        make_grid(),
+        tmp_path,
+        rotate_quarter_turns=0,
+        generator=first_generator,
+    )
+    second = HarmoniResiduals(
+        make_grid(),
+        tmp_path,
+        rotate_quarter_turns=0,
+        generator=second_generator,
+    )
+
+    assert [next(first.iterator) for _ in range(4)] == [
+        next(second.iterator) for _ in range(4)
+    ]
+
+
 def test_missing_non_directory_and_empty_paths_have_actionable_errors(tmp_path):
     with pytest.raises(HarmoniDatasetNotFoundError, match="does not exist"):
         HarmoniResiduals(make_grid(), tmp_path / "missing")

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,147 @@
+from copy import deepcopy
+import pickle
+
+import pytest
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.optics.atmosphere import (
+    KolmogorovAtmosphereModel,
+    NCPAModel,
+)
+from fiatlux.optics.detector import Detector
+from fiatlux.optics.elements.mask import Atmosphere, NCPA, Random
+
+
+def make_grid(device="cpu"):
+    return Grid(
+        nx=12,
+        ny=10,
+        dx=0.1,
+        dy=0.12,
+        device=torch.device(device),
+    )
+
+
+def test_random_masks_with_the_same_seed_replay_the_same_sequence():
+    first = Random(make_grid(), amplitude=100e-9, seed=42)
+    second = Random(make_grid(), amplitude=100e-9, seed=42)
+
+    for _ in range(3):
+        first._build_opd()
+        second._build_opd()
+        torch.testing.assert_close(first.opd, second.opd)
+
+
+def test_different_random_mask_seeds_produce_different_screens():
+    first = Random(make_grid(), amplitude=100e-9, seed=1)
+    second = Random(make_grid(), amplitude=100e-9, seed=2)
+
+    first._build_opd()
+    second._build_opd()
+
+    assert not torch.equal(first.opd, second.opd)
+
+
+def test_running_one_element_does_not_advance_another_element():
+    first = Random(make_grid(), amplitude=1.0, seed=7)
+    second = Random(make_grid(), amplitude=1.0, seed=7)
+
+    first._build_opd()
+    expected_first_screen = first.opd.clone()
+    first._build_opd()
+    second._build_opd()
+
+    torch.testing.assert_close(second.opd, expected_first_screen)
+
+
+def test_stochastic_elements_do_not_modify_the_global_generator():
+    torch.manual_seed(123)
+    expected = torch.rand(4)
+    torch.manual_seed(123)
+
+    random_mask = Random(make_grid(), amplitude=1.0, seed=9)
+    random_mask._build_opd()
+
+    torch.testing.assert_close(torch.rand(4), expected)
+
+
+def test_generator_state_can_be_checkpointed_and_restored():
+    model = NCPAModel(make_grid(), opd_rms=100e-9, seed=12)
+
+    state = model.get_rng_state()
+    expected = model.sample_opd()
+    model.sample_opd()
+    model.set_rng_state(state)
+
+    torch.testing.assert_close(model.sample_opd(), expected)
+
+
+def test_deepcopy_preserves_the_current_generator_state():
+    model = KolmogorovAtmosphereModel(make_grid(), r0=0.2, seed=4)
+    model.sample_opd()
+    copied = deepcopy(model)
+
+    torch.testing.assert_close(model.sample_opd(), copied.sample_opd())
+
+
+def test_pickle_preserves_the_current_generator_state():
+    random_mask = Random(make_grid(), amplitude=1.0, seed=14)
+    random_mask._build_opd()
+    restored = pickle.loads(pickle.dumps(random_mask))
+
+    random_mask._build_opd()
+    restored._build_opd()
+
+    torch.testing.assert_close(random_mask.opd, restored.opd)
+
+
+def test_wrappers_accept_independent_seeds():
+    grid = make_grid()
+    atmosphere_model = KolmogorovAtmosphereModel(grid, r0=0.2, seed=1)
+    ncpa_model = NCPAModel(grid, opd_rms=100e-9, seed=1)
+
+    atmosphere_a = Atmosphere(grid, atmosphere_model, seed=31)
+    atmosphere_b = Atmosphere(grid, atmosphere_model, seed=31)
+    ncpa_a = NCPA(grid, ncpa_model, seed=47)
+    ncpa_b = NCPA(grid, ncpa_model, seed=47)
+
+    atmosphere_a._build_opd()
+    atmosphere_b._build_opd()
+    ncpa_a._build_opd()
+    ncpa_b._build_opd()
+
+    torch.testing.assert_close(atmosphere_a.opd, atmosphere_b.opd)
+    torch.testing.assert_close(ncpa_a.opd, ncpa_b.opd)
+
+
+def test_detector_accepts_an_external_generator():
+    first_generator = torch.Generator().manual_seed(8)
+    second_generator = torch.Generator().manual_seed(8)
+    first = Detector(make_grid(), photon_noise=True, generator=first_generator)
+    second = Detector(make_grid(), photon_noise=True, generator=second_generator)
+    expected = torch.full((10, 12), 20.0)
+
+    torch.testing.assert_close(
+        first.add_photon_noise(expected),
+        second.add_photon_noise(expected),
+    )
+
+
+def test_seed_and_generator_are_mutually_exclusive():
+    generator = torch.Generator().manual_seed(1)
+
+    with pytest.raises(ValueError, match="either seed or generator"):
+        Random(make_grid(), amplitude=1.0, seed=1, generator=generator)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_reproducibility_on_cuda():
+    first = Random(make_grid("cuda"), amplitude=1.0, seed=22)
+    second = Random(make_grid("cuda"), amplitude=1.0, seed=22)
+
+    first._build_opd()
+    second._build_opd()
+
+    assert first.opd.is_cuda
+    torch.testing.assert_close(first.opd, second.opd)


### PR DESCRIPTION
## Summary

- give atmosphere and NCPA models, their optical wrappers, random masks, detectors, and HARMONI sampling configurable private `torch.Generator` instances
- accept either a seed or an externally supplied device-compatible generator
- remove the remaining dependency on PyTorch's process-wide RNG
- expose `get_rng_state()` and `set_rng_state()` for exact checkpoints
- preserve sequence position through `deepcopy`, pickle, and Torch serialization
- keep HARMONI file ordering deterministic and make shuffled ordering generator-controlled
- generate every random tensor on the component's intended device and dtype

## Behavioral contract

- no seed and no generator: create an independently entropy-seeded private generator
- a seed: create an independently repeatable sequence
- a generator: use that explicit sequence; sharing the same generator is an intentional coupling
- passing both is rejected
- CPU and CUDA generators must match the component device

## Validation

- same seeds replay identical multi-sample sequences
- different seeds diverge
- advancing one component does not advance another
- stochastic components do not modify the global PyTorch RNG
- state checkpoint/restore, deepcopy, and pickle resume at the exact next draw
- external HARMONI and detector generators are covered
- CUDA replay test runs when CUDA is available
- `229 passed, 4 skipped`

Closes #31