### PR TITLE
Remove plotting side effects from numerical builders

### DIFF
--- a/fiatlux/optics/atmosphere.py
+++ b/fiatlux/optics/atmosphere.py
@@ -27,6 +27,52 @@ from fiatlux.core.grid import Grid
 from fiatlux.utils.random import RandomGeneratorMixin
 
 
+def _plot_psd(
+    psd: torch.Tensor,
+    frequency_grid: tuple[torch.Tensor, torch.Tensor],
+    *,
+    title: str,
+    colorbar_label: str,
+):
+    """Create an explicit diagnostic plot for an unshifted 2-D PSD."""
+    try:
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import LogNorm
+    except ImportError as error:
+        raise ImportError(
+            "PSD plotting requires Matplotlib; install it with "
+            "`python -m pip install 'fiatlux[plot]'`."
+        ) from error
+
+    fx, fy = frequency_grid
+    shifted = torch.fft.fftshift(psd).detach().cpu()
+    positive = shifted[shifted > 0]
+    norm = None
+    if positive.numel():
+        norm = LogNorm(
+            vmin=float(positive.min()),
+            vmax=float(positive.max()),
+        )
+
+    fig, ax = plt.subplots()
+    image = ax.imshow(
+        shifted.numpy(),
+        origin="lower",
+        extent=[
+            float(torch.fft.fftshift(fx)[0, 0]),
+            float(torch.fft.fftshift(fx)[0, -1]),
+            float(torch.fft.fftshift(fy)[0, 0]),
+            float(torch.fft.fftshift(fy)[-1, 0]),
+        ],
+        norm=norm,
+    )
+    ax.set_xlabel("Spatial frequency x [cycles/m]")
+    ax.set_ylabel("Spatial frequency y [cycles/m]")
+    ax.set_title(title)
+    fig.colorbar(image, ax=ax, label=colorbar_label)
+    return fig, ax
+
+
 class AtmosphereModel(RandomGeneratorMixin, ABC):
     """Base class for phase-screen statistics on a fixed spatial grid."""
 
@@ -138,6 +184,15 @@ class AtmosphereModel(RandomGeneratorMixin, ABC):
             remove_piston=remove_piston,
         )
         return phase * (self.reference_wavelength / (2.0 * math.pi))
+
+    def plot_psd(self):
+        """Plot the phase PSD explicitly and return its figure and axes."""
+        return _plot_psd(
+            self.phase_psd,
+            self.frequency_grid(),
+            title="Atmospheric phase PSD",
+            colorbar_label=r"$W_\phi$ [rad² m²]",
+        )
 
 
 class KolmogorovAtmosphereModel(AtmosphereModel):
@@ -338,3 +393,12 @@ class NCPAModel(RandomGeneratorMixin):
             * (self.grid.nx * self.grid.ny)
         )
         return torch.fft.ifft2(torch.fft.fft2(white) * transfer).real
+
+    def plot_psd(self):
+        """Plot the OPD PSD explicitly and return its figure and axes."""
+        return _plot_psd(
+            self.opd_psd,
+            self.frequency_grid(),
+            title="NCPA OPD PSD",
+            colorbar_label="OPD PSD [m⁴]",
+        )

--- a/fiatlux/optics/elements/deformable_mirror.py
+++ b/fiatlux/optics/elements/deformable_mirror.py
@@ -197,6 +197,19 @@ class FourierBasis(ControlBasis):
     frequencies: torch.Tensor  # spatial frequencies in cycles per aperture
     pupil: Mask
 
+    def _mode_selection(self) -> torch.Tensor:
+        """Return the sine/cosine selection without graphical side effects."""
+        n_freqs = len(self.frequencies)
+        use_cosine = torch.full(
+            (n_freqs, n_freqs),
+            True,
+            device=self.pixel_grid.device,
+        )
+        center_freq = n_freqs**2 / 2
+        use_cosine[: int(center_freq // n_freqs), :] = False
+        use_cosine[int(center_freq // n_freqs), : int(center_freq % n_freqs)] = False
+        return use_cosine
+
     def build_command_matrix(self):
         frequencies = self.frequencies.to(
             device=self.pixel_grid.device, dtype=self.pixel_grid.dtype
@@ -217,22 +230,7 @@ class FourierBasis(ControlBasis):
 
         # Cosine for freq_x < 0, or freq_x == 0 and freq_y <= 0 (avoids cos/sin redundancy)
         # use_cosine = (freq_x < 0) | ((freq_x <= 0) & (freq_y >= 0))
-        use_cosine = torch.full(
-            (n_freqs, n_freqs), True, device=self.pixel_grid.device
-        )
-        center_freq = n_freqs**2 / 2
-        use_cosine[: int(center_freq // n_freqs), :] = False
-        use_cosine[int(center_freq // n_freqs), : int(center_freq % n_freqs)] = False
-
-        import matplotlib.pyplot as plt
-
-        fig, ax = plt.subplots()
-        ax.imshow(use_cosine)
-        # Minor ticks
-        ax.set_xticks(torch.arange(-0.5, n_freqs, 1), minor=True)
-        ax.set_yticks(torch.arange(-0.5, n_freqs, 1), minor=True)
-        # Gridlines based on minor ticks
-        ax.grid(which="minor", color="w", linestyle="-", linewidth=2)
+        use_cosine = self._mode_selection()
 
         modes = torch.where(
             use_cosine[:, :, None, None], torch.cos(phase), torch.sin(phase)
@@ -243,6 +241,29 @@ class FourierBasis(ControlBasis):
         ).pow(2).sum(dim=(2, 3), keepdim=True).sqrt()
 
         return modes.reshape(n_freqs**2, self.pixel_grid.nx * self.pixel_grid.ny).T
+
+    def plot_mode_selection(self):
+        """Plot which Fourier modes use cosine or sine and return the axes."""
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError as error:
+            raise ImportError(
+                "Basis plotting requires Matplotlib; install it with "
+                "`python -m pip install 'fiatlux[plot]'`."
+            ) from error
+
+        selection = self._mode_selection().detach().cpu()
+        n_freqs = selection.shape[0]
+        fig, ax = plt.subplots()
+        image = ax.imshow(selection.numpy(), origin="lower")
+        ax.set_xticks(torch.arange(-0.5, n_freqs, 1), minor=True)
+        ax.set_yticks(torch.arange(-0.5, n_freqs, 1), minor=True)
+        ax.grid(which="minor", color="w", linestyle="-", linewidth=2)
+        ax.set_xlabel("Frequency-index x")
+        ax.set_ylabel("Frequency-index y")
+        ax.set_title("Fourier basis mode selection")
+        fig.colorbar(image, ax=ax, ticks=[0, 1], label="0: sine, 1: cosine")
+        return fig, ax
 
     # def build_command_matrix(
     #     self,

--- a/tests/test_plotting_side_effects.py
+++ b/tests/test_plotting_side_effects.py
@@ -1,0 +1,70 @@
+import matplotlib.pyplot as plt
+import torch
+
+from fiatlux.core.grid import Grid
+from fiatlux.optics.atmosphere import (
+    KolmogorovAtmosphereModel,
+    NCPAModel,
+)
+from fiatlux.optics.elements.deformable_mirror import (
+    ActuatorGrid,
+    DeformableMirror,
+    FourierBasis,
+)
+from fiatlux.optics.elements.mask import CircularAperture
+from fiatlux.optics.propagator import MFTPropagator
+
+
+def make_fourier_basis():
+    grid = Grid(nx=12, ny=10, dx=0.1, dy=0.1)
+    pupil = CircularAperture(grid, radius=0.45)
+    pupil._build_transmission()
+    return FourierBasis(
+        pixel_grid=grid,
+        frequencies=torch.tensor([-1.0, 0.0, 1.0]),
+        pupil=pupil,
+    )
+
+
+def test_numerical_construction_and_building_open_no_figures():
+    plt.close("all")
+    initial_figures = set(plt.get_fignums())
+    grid = Grid(nx=12, ny=10, dx=0.1, dy=0.1)
+
+    KolmogorovAtmosphereModel(grid, r0=0.2, seed=1)
+    NCPAModel(grid, opd_rms=100e-9, seed=1)
+    basis = make_fourier_basis()
+    basis.build_command_matrix()
+    DeformableMirror(
+        grid=basis.pixel_grid,
+        actuator_grid=ActuatorGrid(1, 1, 1.0),
+        pixel_grid=basis.pixel_grid,
+        control_basis=basis,
+    )
+    MFTPropagator(focal_length=10.0, output_grid=grid)
+
+    assert set(plt.get_fignums()) == initial_figures
+
+
+def test_fourier_diagnostic_is_available_explicitly():
+    basis = make_fourier_basis()
+
+    figure, axes = basis.plot_mode_selection()
+
+    assert figure.number in plt.get_fignums()
+    assert axes.get_title() == "Fourier basis mode selection"
+    plt.close(figure)
+
+
+def test_atmosphere_and_ncpa_psd_diagnostics_are_explicit():
+    grid = Grid(nx=12, ny=10, dx=0.1, dy=0.1)
+    atmosphere = KolmogorovAtmosphereModel(grid, r0=0.2, seed=1)
+    ncpa = NCPAModel(grid, opd_rms=100e-9, seed=1)
+
+    atmosphere_figure, _ = atmosphere.plot_psd()
+    ncpa_figure, _ = ncpa.plot_psd()
+
+    assert atmosphere_figure.number in plt.get_fignums()
+    assert ncpa_figure.number in plt.get_fignums()
+    plt.close(atmosphere_figure)
+    plt.close(ncpa_figure)


### PR DESCRIPTION
## Summary

- remove the implicit Matplotlib figure creation from `FourierBasis.build_command_matrix()`
- expose the former sine/cosine diagnostic through `plot_mode_selection()`
- add explicit `plot_psd()` diagnostics to atmosphere and NCPA models
- keep every Matplotlib import inside an explicitly requested plotting method
- provide actionable `fiatlux[plot]` installation errors
- convert plotted tensors to detached CPU NumPy arrays

## Validation

- regression test constructs atmosphere/NCPA models, a Fourier-basis DM, and a propagator without changing Matplotlib's open figure set
- explicit diagnostic methods are tested and return their figure/axes
- `232 passed, 4 skipped`
- headless test run uses `MPLBACKEND=Agg`

Closes #35