### PR TITLE
Implement MFT/FFT propagation in Fraunhofer and Fresnel regimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ photon_rate_k = field.intensity()[k].sum() * field.grid.dx * field.grid.dy
 
 ### Fourier optics
 
-Fiatlux provides matrix Fourier transform propagation between arbitrarily sampled pupil and focal planes.
+Fiatlux provides MFT and FFT propagation in Fraunhofer and Fresnel regimes.
+Fraunhofer is the default. MFT supports arbitrarily sampled output planes;
+FFT uses its natural conjugate sampling.
 
 ```python
-from fiatlux.optics.propagator import MFTPropagator
+from fiatlux.optics.propagator import FFTPropagator, MFTPropagator
 ```
 
 Optical systems can mix propagation and optical elements in a single ordered sequence.

--- a/docs/near_field_propagation.md
+++ b/docs/near_field_propagation.md
@@ -15,14 +15,14 @@ and checks MFT/FFT agreement on their common sampling.
 
 ## Public API
 
-The intended API is:
+The public API is:
 
 ```python
-MFTPropagator(..., propagation="fraunhofer")
-MFTPropagator(..., propagation="fresnel", distance=z)
+MFTPropagator(focal_length=f, output_grid=grid)
+MFTPropagator(output_grid=grid, propagation="fresnel", distance=z)
 
-FFTPropagator(..., propagation="fraunhofer")
-FFTPropagator(..., propagation="fresnel", distance=z)
+FFTPropagator(focal_length=f)
+FFTPropagator(propagation="fresnel", distance=z)
 ```
 
 `propagation` accepts the public `PropagationRegime` values `FRAUNHOFER` and
@@ -45,15 +45,13 @@ input with `nx`, `dx` and propagation scale `q`, its output sampling is
 \]
 
 Here `q` is the focal length for Fraunhofer propagation through a lens and the
-propagation distance for the single-transform Fresnel formulation. An
-incompatible user-supplied FFT output grid raises `PropagationSamplingError`;
-it is never silently resampled.
+propagation distance for the single-transform Fresnel formulation. The FFT
+propagator constructs this grid explicitly and never silently resamples it.
 
-Because the natural FFT grid depends on wavelength, a polychromatic FFT needs
-an explicit sampling policy. The first implementation may either return a
-per-wavelength grid representation or reject incompatible multi-wavelength
-requests with an actionable error. It must not label chromatically different
-physical coordinates with one common grid.
+Because the natural FFT grid depends on wavelength and `Field` currently owns
+one spatial grid, `FFTPropagator` accepts monochromatic fields. A polychromatic
+request raises `PropagationSamplingError` and points users to `MFTPropagator`
+for propagation onto a common physical grid.
 
 ## Coordinates and Fourier convention
 

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -31,6 +31,7 @@ from .system.interaction_matrix import InteractionMatrix
 # =========================
 
 from .optics.propagator import (
+    FFTPropagator,
     Propagator,
     PropagationRegime,
     PropagationSamplingError,
@@ -101,6 +102,7 @@ __all__ = [
     "InteractionMatrix",
     # Optics
     "Propagator",
+    "FFTPropagator",
     "PropagationRegime",
     "PropagationSamplingError",
     "IdentityPropagator",

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -2,6 +2,8 @@ from .adc import ADCDispersionModel
 from .atmosphere import AtmosphereModel, KolmogorovAtmosphereModel, NCPAModel
 from .detector import Detector
 from .propagator import (
+    FFTPropagator,
+    MFTPropagator,
     PropagationRegime,
     PropagationSamplingError,
     Propagator,
@@ -13,6 +15,8 @@ __all__ = [
     "KolmogorovAtmosphereModel",
     "NCPAModel",
     "Detector",
+    "FFTPropagator",
+    "MFTPropagator",
     "PropagationRegime",
     "PropagationSamplingError",
     "Propagator",

--- a/fiatlux/optics/propagator.py
+++ b/fiatlux/optics/propagator.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+import math
 
 from fiatlux.core.field import Field
 from fiatlux.core.grid import Grid
@@ -30,18 +31,74 @@ class PropagationRegime(str, Enum):
     FRESNEL = "fresnel"
 
 
-@dataclass
+def _coerce_regime(value: PropagationRegime | str) -> PropagationRegime:
+    try:
+        return PropagationRegime(value)
+    except ValueError as error:
+        choices = ", ".join(regime.value for regime in PropagationRegime)
+        raise ValueError(
+            f"propagation must be one of {choices}; got {value!r}."
+        ) from error
+
+
+def _validate_scale(value: float | None, name: str, *, allow_zero: bool) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise TypeError(f"{name} must be a real number in metres.")
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite.")
+    if not allow_zero and value == 0:
+        raise ValueError(f"{name} must be non-zero.")
+    return value
+
+
+@dataclass(init=False)
 @register_type("MFTPropagator")
 class MFTPropagator(Propagator):
-    """Matrix Fourier transform from a Field grid to ``output_grid``.
+    """MFT propagation in the Fraunhofer or Fresnel regime.
 
     Input amplitudes have shape ``(n_wavelengths, ny_in, nx_in)`` and output
     amplitudes have shape ``(n_wavelengths, output_grid.ny, output_grid.nx)``.
     Input and output grids must share device and real dtype. Wavelength
     channels are propagated independently and retain their original order.
+    Fraunhofer is the default and preserves the historical Fiatlux behavior.
     """
-    focal_length: float
+    focal_length: float | None
     output_grid: Grid
+    propagation: PropagationRegime
+    distance: float | None
+
+    def __init__(
+        self,
+        focal_length: float | None = None,
+        output_grid: Grid | None = None,
+        *,
+        propagation: PropagationRegime | str = PropagationRegime.FRAUNHOFER,
+        distance: float | None = None,
+    ) -> None:
+        if not isinstance(output_grid, Grid):
+            raise TypeError("output_grid must be a fiatlux Grid.")
+        self.propagation = _coerce_regime(propagation)
+        self.output_grid = output_grid
+        self.distance = distance
+        self.focal_length = focal_length
+
+        if self.propagation is PropagationRegime.FRAUNHOFER:
+            self.focal_length = _validate_scale(
+                focal_length, "focal_length", allow_zero=False
+            )
+            if distance is not None:
+                raise ValueError("distance is only valid for Fresnel propagation.")
+        else:
+            self.distance = _validate_scale(distance, "distance", allow_zero=True)
+
+    @property
+    def _scale(self) -> float:
+        if self.propagation is PropagationRegime.FRAUNHOFER:
+            assert self.focal_length is not None
+            return self.focal_length
+        assert self.distance is not None
+        return self.distance
 
     @staticmethod
     def _mft_matrix(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
@@ -75,6 +132,10 @@ class MFTPropagator(Propagator):
                 f"grid dtype; got {self.output_grid.dtype} and {field.grid.dtype}."
             )
 
+        if self.propagation is PropagationRegime.FRESNEL and self._scale == 0:
+            validate_field_grid(field, self.output_grid, "MFTPropagator")
+            return Field(field.complex_amplitude, self.output_grid, field.spectrum)
+
         x, y = field.grid.x, field.grid.y
         u, v = self.output_grid.x, self.output_grid.y
 
@@ -88,20 +149,149 @@ class MFTPropagator(Propagator):
         def propagate_one(
             amplitude: torch.Tensor, wavelength: torch.Tensor
         ) -> torch.Tensor:
-            mx = self._dft_matrix(x, u, wavelength, self.focal_length)
-            my = self._dft_matrix(y, v, wavelength, self.focal_length)
-            return (
+            scale = self._scale
+            if self.propagation is PropagationRegime.FRESNEL:
+                coefficient = torch.pi / (wavelength * scale)
+                input_chirp = torch.exp(
+                    1j * coefficient * (y[:, None].square() + x[None, :].square())
+                )
+                amplitude = amplitude * input_chirp
+
+            mx = self._dft_matrix(x, u, wavelength, scale)
+            my = self._dft_matrix(y, v, wavelength, scale)
+            propagated = (
                 (my.T @ amplitude @ mx)
                 * field.grid.dx
                 * field.grid.dy
-                / (wavelength * self.focal_length)
+                / (wavelength * scale)
             )
+
+            if self.propagation is PropagationRegime.FRESNEL:
+                coefficient = torch.pi / (wavelength * scale)
+                output_chirp = torch.exp(
+                    1j * coefficient * (v[:, None].square() + u[None, :].square())
+                )
+                carrier = torch.exp(2j * torch.pi * scale / wavelength)
+                propagated = carrier / 1j * output_chirp * propagated
+            return propagated
 
         # field.complex_amplitude: (n_wavelengths, ny_in, nx_in)
         # amplitude: (n_wavelengths, ny_out, nx_out)
         amplitude = torch.vmap(propagate_one)(field.complex_amplitude, wavelengths)
 
         return Field(amplitude, self.output_grid, field.spectrum)
+
+    @property
+    def _symbol(self) -> str:
+        return ">"
+
+
+@dataclass
+@register_type("FFTPropagator")
+class FFTPropagator(Propagator):
+    """FFT propagation on the wavelength-dependent natural output grid.
+
+    The current ``Field`` model stores one spatial grid for all wavelength
+    channels, so this propagator deliberately accepts monochromatic fields
+    only. MFT propagation remains available for polychromatic fields on a
+    common explicitly sampled output grid.
+    """
+
+    focal_length: float | None = None
+    propagation: PropagationRegime | str = PropagationRegime.FRAUNHOFER
+    distance: float | None = None
+
+    def __post_init__(self) -> None:
+        self.propagation = _coerce_regime(self.propagation)
+        if self.propagation is PropagationRegime.FRAUNHOFER:
+            self.focal_length = _validate_scale(
+                self.focal_length, "focal_length", allow_zero=False
+            )
+            if self.distance is not None:
+                raise ValueError("distance is only valid for Fresnel propagation.")
+        else:
+            self.distance = _validate_scale(
+                self.distance, "distance", allow_zero=True
+            )
+
+    @property
+    def _scale(self) -> float:
+        if self.propagation is PropagationRegime.FRAUNHOFER:
+            assert self.focal_length is not None
+            return self.focal_length
+        assert self.distance is not None
+        return self.distance
+
+    def output_grid_for(self, field: Field) -> Grid:
+        """Return the natural physical output grid for a monochromatic field."""
+        if not isinstance(field, Field):
+            raise TypeError(
+                f"FFTPropagator expects a Field, got {type(field).__name__}."
+            )
+        if field.complex_amplitude.shape[0] != 1:
+            raise PropagationSamplingError(
+                "FFTPropagator currently requires a monochromatic Field because "
+                "its physical output sampling depends on wavelength; use "
+                "MFTPropagator for a polychromatic common output grid."
+            )
+        if self.propagation is PropagationRegime.FRESNEL and self._scale == 0:
+            return field.grid
+
+        wavelength = float(field.spectrum.wavelengths[0])
+        scale = abs(self._scale)
+        return Grid(
+            nx=field.grid.nx,
+            ny=field.grid.ny,
+            dx=wavelength * scale / (field.grid.nx * field.grid.dx),
+            dy=wavelength * scale / (field.grid.ny * field.grid.dy),
+            device=field.grid.device,
+            dtype=field.grid.dtype,
+        )
+
+    def apply(self, field: Field) -> Field:
+        output_grid = self.output_grid_for(field)
+        if self.propagation is PropagationRegime.FRESNEL and self._scale == 0:
+            return field
+
+        amplitude = field.complex_amplitude[0]
+        wavelength = field.spectrum.wavelengths[0].to(
+            dtype=amplitude.real.dtype, device=amplitude.device
+        )
+        scale = self._scale
+
+        if self.propagation is PropagationRegime.FRESNEL:
+            x, y = field.grid.meshgrid()
+            coefficient = torch.pi / (wavelength * scale)
+            amplitude = amplitude * torch.exp(
+                1j * coefficient * (x.square() + y.square())
+            )
+
+        if scale > 0:
+            transformed = torch.fft.fftshift(
+                torch.fft.fft2(torch.fft.ifftshift(amplitude), norm="backward")
+            )
+        else:
+            transformed = torch.fft.fftshift(
+                torch.fft.ifft2(torch.fft.ifftshift(amplitude), norm="backward")
+            ) * (field.grid.nx * field.grid.ny)
+
+        propagated = (
+            transformed
+            * field.grid.dx
+            * field.grid.dy
+            / (wavelength * scale)
+        )
+
+        if self.propagation is PropagationRegime.FRESNEL:
+            x_out, y_out = output_grid.meshgrid()
+            coefficient = torch.pi / (wavelength * scale)
+            output_chirp = torch.exp(
+                1j * coefficient * (x_out.square() + y_out.square())
+            )
+            carrier = torch.exp(2j * torch.pi * scale / wavelength)
+            propagated = carrier / 1j * output_chirp * propagated
+
+        return Field(propagated.unsqueeze(0), output_grid, field.spectrum)
 
     @property
     def _symbol(self) -> str:

--- a/tests/test_fourier_propagation.py
+++ b/tests/test_fourier_propagation.py
@@ -1,0 +1,219 @@
+import pytest
+import torch
+
+from fiatlux.core.field import Field
+from fiatlux.core.grid import Grid
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.propagator import (
+    FFTPropagator,
+    MFTPropagator,
+    PropagationRegime,
+    PropagationSamplingError,
+)
+
+
+WAVELENGTH = 632.8e-9
+SCALE = 0.2
+
+
+def make_field(nx=9, ny=7, *, samples=1, dtype=torch.float64):
+    grid = Grid(nx, ny, 20e-6, 30e-6, dtype=dtype)
+    spectrum = Spectrum(
+        magnitude=0,
+        band=Band(WAVELENGTH, 20e-9 if samples > 1 else 0.0, 1.0),
+        samples=samples,
+        dtype=dtype,
+    )
+    complex_dtype = torch.complex64 if dtype == torch.float32 else torch.complex128
+    generator = torch.Generator().manual_seed(12)
+    real = torch.randn(samples, ny, nx, generator=generator, dtype=dtype)
+    imaginary = torch.randn(samples, ny, nx, generator=generator, dtype=dtype)
+    amplitude = torch.complex(real, imaginary).to(complex_dtype)
+    return Field(amplitude, grid, spectrum)
+
+
+def natural_grid(field, scale=SCALE):
+    wavelength = float(field.spectrum.wavelengths[0])
+    return Grid(
+        field.grid.nx,
+        field.grid.ny,
+        wavelength * abs(scale) / (field.grid.nx * field.grid.dx),
+        wavelength * abs(scale) / (field.grid.ny * field.grid.dy),
+        dtype=field.grid.dtype,
+        device=field.grid.device,
+    )
+
+
+def integrated_flux(field):
+    return field.intensity().sum(dim=(-2, -1)) * field.grid.dx * field.grid.dy
+
+
+def test_fraunhofer_is_default_for_both_numerical_methods():
+    field = make_field()
+    grid = natural_grid(field)
+
+    assert MFTPropagator(SCALE, grid).propagation is PropagationRegime.FRAUNHOFER
+    assert FFTPropagator(SCALE).propagation is PropagationRegime.FRAUNHOFER
+
+
+@pytest.mark.parametrize("regime", list(PropagationRegime))
+@pytest.mark.parametrize("shape", [(9, 7), (8, 6)])
+def test_mft_and_fft_agree_on_natural_output_grid(regime, shape):
+    field = make_field(nx=shape[0], ny=shape[1])
+    output_grid = natural_grid(field)
+
+    if regime is PropagationRegime.FRAUNHOFER:
+        mft = MFTPropagator(SCALE, output_grid)
+        fft = FFTPropagator(SCALE)
+    else:
+        mft = MFTPropagator(
+            output_grid=output_grid, propagation=regime, distance=SCALE
+        )
+        fft = FFTPropagator(propagation=regime, distance=SCALE)
+
+    mft_field = mft.apply(field)
+    fft_field = fft.apply(field)
+    torch.testing.assert_close(
+        mft_field.complex_amplitude,
+        fft_field.complex_amplitude,
+        rtol=2e-10,
+        atol=2e-10,
+    )
+
+
+@pytest.mark.parametrize("regime", list(PropagationRegime))
+def test_mft_and_fft_preserve_flux_on_natural_grid(regime):
+    field = make_field()
+    grid = natural_grid(field)
+    if regime is PropagationRegime.FRAUNHOFER:
+        propagators = [MFTPropagator(SCALE, grid), FFTPropagator(SCALE)]
+    else:
+        propagators = [
+            MFTPropagator(output_grid=grid, propagation=regime, distance=SCALE),
+            FFTPropagator(propagation=regime, distance=SCALE),
+        ]
+
+    for propagator in propagators:
+        torch.testing.assert_close(
+            integrated_flux(propagator.apply(field)),
+            integrated_flux(field),
+            rtol=2e-10,
+            atol=2e-10,
+        )
+
+
+def test_negative_fresnel_distance_agrees_between_mft_and_fft():
+    field = make_field()
+    grid = natural_grid(field, scale=-SCALE)
+    mft = MFTPropagator(
+        output_grid=grid, propagation="fresnel", distance=-SCALE
+    ).apply(field)
+    fft = FFTPropagator(propagation="fresnel", distance=-SCALE).apply(field)
+
+    torch.testing.assert_close(
+        mft.complex_amplitude, fft.complex_amplitude, rtol=2e-10, atol=2e-10
+    )
+    torch.testing.assert_close(
+        integrated_flux(fft), integrated_flux(field), rtol=2e-10, atol=2e-10
+    )
+
+
+def test_fresnel_mft_supports_polychromatic_fields_on_a_common_grid():
+    field = make_field(samples=3)
+    output = MFTPropagator(
+        output_grid=natural_grid(make_field()),
+        propagation="fresnel",
+        distance=SCALE,
+    ).apply(field)
+
+    assert output.complex_amplitude.shape == (3, field.grid.ny, field.grid.nx)
+    assert output.spectrum is field.spectrum
+
+
+def test_fft_rejects_polychromatic_field_with_actionable_error():
+    field = make_field(samples=3)
+    with pytest.raises(
+        PropagationSamplingError, match="monochromatic.*MFTPropagator"
+    ):
+        FFTPropagator(SCALE).apply(field)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("regime", list(PropagationRegime))
+def test_fft_preserves_dtype_device_and_shape(dtype, regime):
+    field = make_field(dtype=dtype)
+    if regime is PropagationRegime.FRAUNHOFER:
+        output = FFTPropagator(SCALE).apply(field)
+    else:
+        output = FFTPropagator(propagation=regime, distance=SCALE).apply(field)
+
+    assert output.complex_amplitude.dtype == field.complex_amplitude.dtype
+    assert output.complex_amplitude.device == field.complex_amplitude.device
+    assert output.complex_amplitude.shape == field.complex_amplitude.shape
+    assert output.grid.dtype == field.grid.dtype
+
+
+@pytest.mark.parametrize("regime", list(PropagationRegime))
+@pytest.mark.parametrize("method", ["mft", "fft"])
+def test_propagation_is_differentiable_with_respect_to_input_field(regime, method):
+    field = make_field()
+    amplitude = field.complex_amplitude.detach().requires_grad_(True)
+    differentiable_field = Field(amplitude, field.grid, field.spectrum)
+    output_grid = natural_grid(field)
+    if method == "mft" and regime is PropagationRegime.FRAUNHOFER:
+        propagator = MFTPropagator(SCALE, output_grid)
+    elif method == "mft":
+        propagator = MFTPropagator(
+            output_grid=output_grid, propagation=regime, distance=SCALE
+        )
+    elif regime is PropagationRegime.FRAUNHOFER:
+        propagator = FFTPropagator(SCALE)
+    else:
+        propagator = FFTPropagator(propagation=regime, distance=SCALE)
+
+    output = propagator.apply(differentiable_field)
+
+    output.intensity().square().sum().backward()
+    assert amplitude.grad is not None
+    assert torch.isfinite(amplitude.grad).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+@pytest.mark.parametrize("regime", list(PropagationRegime))
+def test_fft_runs_on_cuda(regime):
+    field = make_field().to(device="cuda")
+    if regime is PropagationRegime.FRAUNHOFER:
+        output = FFTPropagator(SCALE).apply(field)
+    else:
+        output = FFTPropagator(propagation=regime, distance=SCALE).apply(field)
+
+    assert output.complex_amplitude.device.type == "cuda"
+    assert output.grid.device.type == "cuda"
+
+
+def test_zero_distance_fresnel_is_exact_identity():
+    field = make_field()
+    fft_output = FFTPropagator(propagation="fresnel", distance=0).apply(field)
+    mft_output = MFTPropagator(
+        output_grid=field.grid, propagation="fresnel", distance=0
+    ).apply(field)
+
+    assert fft_output is field
+    torch.testing.assert_close(
+        mft_output.complex_amplitude, field.complex_amplitude, rtol=0, atol=0
+    )
+
+
+def test_fresnel_requires_an_explicit_finite_distance():
+    field = make_field()
+    with pytest.raises(TypeError, match="distance"):
+        FFTPropagator(propagation="fresnel")
+    with pytest.raises(ValueError, match="finite"):
+        MFTPropagator(
+            output_grid=field.grid, propagation="fresnel", distance=float("nan")
+        )
+
+
+def test_unknown_regime_is_rejected():
+    with pytest.raises(ValueError, match="fraunhofer, fresnel"):
+        FFTPropagator(SCALE, propagation="nearish")

--- a/tutorials/08_near_field_propagation_contract.ipynb
+++ b/tutorials/08_near_field_propagation_contract.ipynb
@@ -4,14 +4,14 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# MFT and FFT propagation: Fraunhofer and Fresnel\n\nThis notebook makes the 2 × 2 propagation contract executable. **MFT versus FFT selects the numerical transform; Fraunhofer versus Fresnel selects the physical regime.** Fraunhofer is the default regime for both methods. The compact reference functions below will be replaced by the public implementation."
+        "# MFT and FFT propagation: Fraunhofer and Fresnel\n\nThis notebook exercises the production 2 × 2 propagation API. **MFT versus FFT selects the numerical transform; Fraunhofer versus Fresnel selects the physical regime.** Fraunhofer is the default regime for both methods."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "import matplotlib.pyplot as plt\nimport torch\n\nfrom fiatlux.core import Grid\n\ntorch.set_default_dtype(torch.float64)\n\nwavelength = 632.8e-9\npropagation_scale = 0.20  # focal length for Fraunhofer, distance for Fresnel\nn = 65  # odd sampling keeps the centred spatial and FFT origins aligned\ndx = 20e-6\ninput_grid = Grid(nx=n, ny=n, dx=dx, dy=dx, dtype=torch.float64)\noutput_dx = wavelength * propagation_scale / (n * dx)\noutput_grid = Grid(\n    nx=n, ny=n, dx=output_dx, dy=output_dx, dtype=torch.float64\n)\n\nx, y = input_grid.meshgrid()\nr2 = x.square() + y.square()\nwaist = 0.18e-3\ninput_field = torch.exp(-r2 / waist**2).to(torch.complex128)\ninput_field /= (\n    input_field.abs().square().sum() * input_grid.dx * input_grid.dy\n).sqrt()\n\nprint(f\"input sampling:  {input_grid.dx * 1e6:.2f} µm\")\nprint(f\"natural output sampling: {output_grid.dx * 1e6:.2f} µm\")"
+        "import matplotlib.pyplot as plt\nimport torch\n\nfrom fiatlux import (\n    FFTPropagator, Field, Grid, MFTPropagator, PropagationRegime, Spectrum\n)\nfrom fiatlux.core.spectrum import Band\n\ntorch.set_default_dtype(torch.float64)\n\nwavelength = 632.8e-9\npropagation_scale = 0.20  # focal length for Fraunhofer, distance for Fresnel\nn = 65\ndx = 20e-6\ninput_grid = Grid(nx=n, ny=n, dx=dx, dy=dx, dtype=torch.float64)\noutput_dx = wavelength * propagation_scale / (n * dx)\noutput_grid = Grid(\n    nx=n, ny=n, dx=output_dx, dy=output_dx, dtype=torch.float64\n)\n\nx, y = input_grid.meshgrid()\nr2 = x.square() + y.square()\nwaist = 0.18e-3\namplitude = torch.exp(-r2 / waist**2).to(torch.complex128)\namplitude /= (amplitude.abs().square().sum() * input_grid.dx * input_grid.dy).sqrt()\nspectrum = Spectrum(\n    magnitude=0, band=Band(wavelength, 0.0, 1.0), samples=1, dtype=torch.float64\n)\ninput_field = Field(amplitude.unsqueeze(0), input_grid, spectrum)\n\nprint(f\"input sampling:  {input_grid.dx * 1e6:.2f} µm\")\nprint(f\"natural output sampling: {output_grid.dx * 1e6:.2f} µm\")"
       ],
       "execution_count": null,
       "outputs": []
@@ -20,14 +20,14 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Numerical transforms\n\nThe MFT evaluates the Fourier integral on explicit coordinates. The FFT evaluates it on its natural conjugate grid, whose sampling obeys \\(dx_2=\\lambda q/(n_x dx_1)\\). On that common grid the complex results must agree."
+        "## Numerical transforms\n\nThe MFT evaluates the Fourier integral on an explicit `output_grid`. The FFT constructs its natural conjugate grid, whose sampling obeys \\(dx_2=\\lambda q/(n_x dx_1)\\). On that common grid the complex results must agree."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "def mft2(field, input_grid, output_grid, wavelength, scale):\n    mx = torch.exp(\n        -2j * torch.pi * torch.outer(\n            input_grid.x, output_grid.x / (wavelength * scale)\n        )\n    )\n    my = torch.exp(\n        -2j * torch.pi * torch.outer(\n            input_grid.y, output_grid.y / (wavelength * scale)\n        )\n    )\n    return (\n        my.T @ field @ mx\n        * input_grid.dx * input_grid.dy\n        / (wavelength * scale)\n    )\n\n\ndef fft2(field, input_grid, wavelength, scale):\n    return (\n        torch.fft.fftshift(\n            torch.fft.fft2(torch.fft.ifftshift(field), norm=\"backward\")\n        )\n        * input_grid.dx * input_grid.dy\n        / (wavelength * scale)\n    )"
+        "fraunhofer_mft_propagator = MFTPropagator(\n    focal_length=propagation_scale, output_grid=output_grid\n)\nfraunhofer_fft_propagator = FFTPropagator(focal_length=propagation_scale)\n\nfresnel_mft_propagator = MFTPropagator(\n    output_grid=output_grid,\n    propagation=PropagationRegime.FRESNEL,\n    distance=propagation_scale,\n)\nfresnel_fft_propagator = FFTPropagator(\n    propagation=PropagationRegime.FRESNEL, distance=propagation_scale\n)"
       ],
       "execution_count": null,
       "outputs": []
@@ -43,7 +43,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "def propagate(field, method, regime):\n    transform = mft2 if method == \"mft\" else fft2\n\n    if regime == \"fraunhofer\":\n        if method == \"mft\":\n            return transform(\n                field, input_grid, output_grid, wavelength, propagation_scale\n            )\n        return transform(field, input_grid, wavelength, propagation_scale)\n\n    if regime != \"fresnel\":\n        raise ValueError(f\"unknown propagation regime: {regime}\")\n\n    k = 2 * torch.pi / wavelength\n    input_chirp = torch.exp(1j * k * r2 / (2 * propagation_scale))\n    x2, y2 = output_grid.meshgrid()\n    output_chirp = torch.exp(\n        1j * k * (x2.square() + y2.square()) / (2 * propagation_scale)\n    )\n    if method == \"mft\":\n        transformed = transform(\n            field * input_chirp,\n            input_grid,\n            output_grid,\n            wavelength,\n            propagation_scale,\n        )\n    else:\n        transformed = transform(\n            field * input_chirp, input_grid, wavelength, propagation_scale\n        )\n    carrier = torch.exp(\n        torch.as_tensor(1j * k * propagation_scale, dtype=field.dtype)\n    )\n    return carrier / 1j * output_chirp * transformed\n\n\nfraunhofer_mft = propagate(input_field, \"mft\", \"fraunhofer\")\nfraunhofer_fft = propagate(input_field, \"fft\", \"fraunhofer\")\nfresnel_mft = propagate(input_field, \"mft\", \"fresnel\")\nfresnel_fft = propagate(input_field, \"fft\", \"fresnel\")"
+        "fraunhofer_mft = fraunhofer_mft_propagator.apply(input_field)\nfraunhofer_fft = fraunhofer_fft_propagator.apply(input_field)\nfresnel_mft = fresnel_mft_propagator.apply(input_field)\nfresnel_fft = fresnel_fft_propagator.apply(input_field)"
       ],
       "execution_count": null,
       "outputs": []
@@ -59,7 +59,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "torch.testing.assert_close(fraunhofer_mft, fraunhofer_fft, rtol=1e-10, atol=1e-10)\ntorch.testing.assert_close(fresnel_mft, fresnel_fft, rtol=1e-10, atol=1e-10)\n\ndef flux(field, grid):\n    return field.abs().square().sum() * grid.dx * grid.dy\n\ninput_flux = flux(input_field, input_grid)\nfor name, field in {\n    \"MFT Fraunhofer\": fraunhofer_mft,\n    \"FFT Fraunhofer\": fraunhofer_fft,\n    \"MFT Fresnel\": fresnel_mft,\n    \"FFT Fresnel\": fresnel_fft,\n}.items():\n    output_flux = flux(field, output_grid)\n    torch.testing.assert_close(output_flux, input_flux, rtol=1e-10, atol=1e-12)\n    print(f\"{name:17s}: flux = {float(output_flux):.12f}\")"
+        "torch.testing.assert_close(\n    fraunhofer_mft.complex_amplitude, fraunhofer_fft.complex_amplitude,\n    rtol=1e-10, atol=1e-10,\n)\ntorch.testing.assert_close(\n    fresnel_mft.complex_amplitude, fresnel_fft.complex_amplitude,\n    rtol=1e-10, atol=1e-10,\n)\n\ndef flux(field):\n    return field.intensity().sum() * field.grid.dx * field.grid.dy\n\ninput_flux = flux(input_field)\nfor name, field in {\n    \"MFT Fraunhofer\": fraunhofer_mft,\n    \"FFT Fraunhofer\": fraunhofer_fft,\n    \"MFT Fresnel\": fresnel_mft,\n    \"FFT Fresnel\": fresnel_fft,\n}.items():\n    output_flux = flux(field)\n    torch.testing.assert_close(output_flux, input_flux, rtol=1e-10, atol=1e-12)\n    print(f\"{name:17s}: flux = {float(output_flux):.12f}\")"
       ],
       "execution_count": null,
       "outputs": []
@@ -75,7 +75,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "fields = [\n    fraunhofer_mft, fraunhofer_fft, fresnel_mft, fresnel_fft\n]\ntitles = [\n    \"MFT · Fraunhofer\", \"FFT · Fraunhofer\",\n    \"MFT · Fresnel\", \"FFT · Fresnel\",\n]\nextent_mm = [\n    float(output_grid.x.min() * 1e3), float(output_grid.x.max() * 1e3),\n    float(output_grid.y.min() * 1e3), float(output_grid.y.max() * 1e3),\n]\nfig, axes = plt.subplots(2, 2, figsize=(9, 8), constrained_layout=True)\nfor ax, field, title in zip(axes.flat, fields, titles):\n    image = ax.imshow(\n        field.abs().square().detach().cpu().numpy(),\n        origin=\"lower\",\n        extent=extent_mm,\n    )\n    ax.set_title(title)\n    ax.set_xlabel(\"x [mm]\")\n    ax.set_ylabel(\"y [mm]\")\n    fig.colorbar(image, ax=ax)\nplt.show()"
+        "fields = [fraunhofer_mft, fraunhofer_fft, fresnel_mft, fresnel_fft]\ntitles = [\n    \"MFT · Fraunhofer\", \"FFT · Fraunhofer\",\n    \"MFT · Fresnel\", \"FFT · Fresnel\",\n]\nfig, axes = plt.subplots(2, 2, figsize=(9, 8), constrained_layout=True)\nfor ax, field, title in zip(axes.flat, fields, titles):\n    extent_mm = [\n        float(field.grid.x.min() * 1e3), float(field.grid.x.max() * 1e3),\n        float(field.grid.y.min() * 1e3), float(field.grid.y.max() * 1e3),\n    ]\n    image = ax.imshow(\n        field.intensity()[0].detach().cpu().numpy(),\n        origin=\"lower\", extent=extent_mm,\n    )\n    ax.set_title(title)\n    ax.set_xlabel(\"x [mm]\")\n    ax.set_ylabel(\"y [mm]\")\n    fig.colorbar(image, ax=ax)\nplt.show()"
       ],
       "execution_count": null,
       "outputs": []
@@ -84,7 +84,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "The production API must preserve this 2 × 2 structure. Fraunhofer remains the default physical regime for both transform methods; choosing MFT or FFT changes sampling freedom and computational strategy, not the propagation physics."
+        "Fraunhofer remains the default physical regime for both production propagators. MFT accepts a common explicit output grid and supports polychromatic fields. FFT currently accepts monochromatic fields because its natural physical output grid depends on wavelength."
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- implement Fraunhofer and Fresnel propagation with both MFT and FFT
- keep `MFTPropagator(focal_length, output_grid)` fully backward compatible and Fraunhofer by default
- add `FFTPropagator`, also Fraunhofer by default
- implement single-transform Fresnel quadratic phases and physical normalization for both methods
- construct the wavelength-dependent natural FFT output grid
- support polychromatic Fresnel/Fraunhofer MFT on a common explicit grid
- reject polychromatic FFT with an actionable sampling error until `Field` supports wavelength-dependent grids
- preserve dtype, device and PyTorch autograd
- replace notebook reference functions with the production classes

## API

```python
MFTPropagator(focal_length=f, output_grid=grid)
MFTPropagator(output_grid=grid, propagation="fresnel", distance=z)

FFTPropagator(focal_length=f)
FFTPropagator(propagation="fresnel", distance=z)
```

Fraunhofer is the default physical regime for both numerical methods.

## Validation

- MFT/FFT complex-field agreement on natural FFT sampling
- odd/even and rectangular grids
- integrated-flux conservation
- positive, negative and zero Fresnel distances
- mono/polychromatic behavior
- complex64/complex128 preservation
- CPU/CUDA coverage when available
- autograd through MFT and FFT input fields
- existing analytical MFT tests retained unchanged
- production tutorial notebook executed by tutorial CI

Local static validation passed: Python compilation, notebook JSON validation, scoped `git diff --check`, and an independent DFT/FFT coordinate check. Full PyTorch execution is delegated to GitHub Actions because the transient local runtime does not contain PyTorch.

Closes #74