### PR TITLE
Validate Fresnel propagation against analytical solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ A recommended learning path is:
 | `06_elt_pupil_from_harmoni.ipynb` | ELT pupil from HARMONI residual data |
 | `07_closed_loop_ao.ipynb` | End-to-end ZELDA adaptive-optics loop |
 | `08_near_field_propagation_contract.ipynb` | MFT/FFT propagation in Fraunhofer and Fresnel regimes |
+| `09_fresnel_physical_validation.ipynb` | Gaussian beam, far-field limit and Fresnel reversibility |
 
 ---
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -7,7 +7,7 @@ the dependency set declared by the `tutorials` extra:
 python -m pip install -e '.[tutorials]'
 ```
 
-Notebooks 00–05 and 07–08 are self-contained and must execute independently from
+Notebooks 00–05 and 07–09 are self-contained and must execute independently from
 a clean kernel. Notebook 07 demonstrates a complete ZELDA closed loop, from
 interaction-matrix calibration to the converged residual OPD. Continuous
 integration executes each notebook in a separate kernel, so variables and

--- a/tests/test_fresnel_physics.py
+++ b/tests/test_fresnel_physics.py
@@ -1,0 +1,144 @@
+import torch
+
+from fiatlux.core.field import Field
+from fiatlux.core.grid import Grid
+from fiatlux.core.spectrum import Band, Spectrum
+from fiatlux.optics.propagator import FFTPropagator, MFTPropagator
+
+WAVELENGTH = 632.8e-9
+
+
+def make_field(amplitude, grid):
+    spectrum = Spectrum(
+        magnitude=0,
+        band=Band(WAVELENGTH, 0.0, 1.0),
+        samples=1,
+        dtype=grid.dtype,
+        device=grid.device,
+    )
+    return Field(amplitude.to(torch.complex128).unsqueeze(0), grid, spectrum)
+
+
+def test_fresnel_gaussian_beam_radius_curvature_and_gouy_phase():
+    grid = Grid(256, 256, 15e-6, 15e-6, dtype=torch.float64)
+    x, y = grid.meshgrid()
+    radius_squared = x.square() + y.square()
+    waist = 0.15e-3
+    distance = 0.08
+    field = make_field(torch.exp(-radius_squared / waist**2), grid)
+
+    propagated = FFTPropagator(
+        propagation="fresnel", distance=distance
+    ).apply(field)
+    intensity = propagated.intensity()[0]
+    x_out, y_out = propagated.grid.meshgrid()
+    output_radius_squared = x_out.square() + y_out.square()
+
+    rayleigh_distance = torch.pi * waist**2 / WAVELENGTH
+    expected_waist = waist * torch.sqrt(
+        torch.as_tensor(
+            1 + (distance / rayleigh_distance) ** 2, dtype=grid.dtype
+        )
+    )
+    measured_waist = torch.sqrt(
+        2 * (output_radius_squared * intensity).sum() / intensity.sum()
+    )
+    torch.testing.assert_close(measured_waist, expected_waist, rtol=3e-3, atol=0)
+
+    expected_curvature = distance * (1 + (rayleigh_distance / distance) ** 2)
+    center = propagated.grid.ny // 2
+    line = propagated.complex_amplitude[0, center]
+    relative_phase = torch.angle(line * line[center].conj())
+    expected_phase = (
+        torch.pi * propagated.grid.x.square() / (WAVELENGTH * expected_curvature)
+    )
+    core = propagated.grid.x.abs() <= expected_waist
+    wrapped_error = torch.angle(
+        torch.exp(1j * (relative_phase[core] - expected_phase[core]))
+    )
+    assert wrapped_error.abs().max() < 2e-2
+
+    expected_gouy = torch.atan(
+        torch.tensor(distance / rayleigh_distance, dtype=torch.float64)
+    )
+    expected_center_phase = 2 * torch.pi * distance / WAVELENGTH - expected_gouy
+    center_phase_error = torch.angle(
+        torch.exp(1j * (torch.angle(line[center]) - expected_center_phase))
+    )
+    assert center_phase_error.abs() < 2e-2
+
+
+def test_circular_aperture_on_axis_fresnel_intensity_matches_analytic_result():
+    grid = Grid(512, 512, 2.5e-6, 2.5e-6, dtype=torch.float64)
+    x, y = grid.meshgrid()
+    radius = 0.30e-3
+    distance = 0.20
+    aperture = (x.square() + y.square() <= radius**2).to(torch.float64)
+    field = make_field(aperture, grid)
+    origin = Grid(1, 1, 1e-6, 1e-6, dtype=torch.float64)
+
+    propagated = MFTPropagator(
+        output_grid=origin,
+        propagation="fresnel",
+        distance=distance,
+    ).apply(field)
+
+    fresnel_phase = torch.as_tensor(
+        torch.pi * radius**2 / (WAVELENGTH * distance), dtype=grid.dtype
+    )
+    expected_intensity = 4 * torch.sin(fresnel_phase / 2).square()
+    measured_intensity = propagated.intensity()[0, 0, 0]
+    torch.testing.assert_close(
+        measured_intensity, expected_intensity, rtol=2e-2, atol=2e-2
+    )
+
+
+def test_fresnel_intensity_converges_to_fraunhofer_in_far_field():
+    grid = Grid(128, 128, 8e-6, 8e-6, dtype=torch.float64)
+    x, y = grid.meshgrid()
+    radius = 0.10e-3
+    distance = 10.0
+    aperture = (x.square() + y.square() <= radius**2).to(torch.float64)
+    field = make_field(aperture, grid)
+
+    fresnel = FFTPropagator(
+        propagation="fresnel", distance=distance
+    ).apply(field)
+    fraunhofer = FFTPropagator(focal_length=distance).apply(field)
+    fresnel_intensity = fresnel.intensity()[0]
+    fraunhofer_intensity = fraunhofer.intensity()[0]
+    fresnel_intensity = fresnel_intensity / fresnel_intensity.max()
+    fraunhofer_intensity = fraunhofer_intensity / fraunhofer_intensity.max()
+
+    relative_error = torch.linalg.vector_norm(
+        fresnel_intensity - fraunhofer_intensity
+    ) / torch.linalg.vector_norm(fraunhofer_intensity)
+    assert relative_error < 5e-3
+
+
+def test_forward_then_backward_fresnel_recovers_complex_field_and_grid():
+    grid = Grid(64, 48, 20e-6, 30e-6, dtype=torch.float64)
+    generator = torch.Generator().manual_seed(41)
+    amplitude = torch.complex(
+        torch.randn(grid.shape, generator=generator, dtype=torch.float64),
+        torch.randn(grid.shape, generator=generator, dtype=torch.float64),
+    )
+    field = make_field(amplitude, grid)
+    distance = 0.25
+
+    forward = FFTPropagator(
+        propagation="fresnel", distance=distance
+    ).apply(field)
+    recovered = FFTPropagator(
+        propagation="fresnel", distance=-distance
+    ).apply(forward)
+
+    torch.testing.assert_close(
+        recovered.complex_amplitude,
+        field.complex_amplitude,
+        rtol=2e-12,
+        atol=2e-12,
+    )
+    assert recovered.grid.shape == field.grid.shape
+    assert abs(recovered.grid.dx - field.grid.dx) < 1e-15
+    assert abs(recovered.grid.dy - field.grid.dy) < 1e-15

--- a/tutorials/09_fresnel_physical_validation.ipynb
+++ b/tutorials/09_fresnel_physical_validation.ipynb
@@ -1,0 +1,81 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Physical validation of Fresnel propagation\n\nThis notebook compares Fiatlux propagation with Gaussian-beam theory, checks the far-field limit, and demonstrates exact sampled forward/backward recovery."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import matplotlib.pyplot as plt\nimport torch\n\nfrom fiatlux import FFTPropagator, Field, Grid, Spectrum\nfrom fiatlux.core.spectrum import Band\n\ntorch.set_default_dtype(torch.float64)\n\nwavelength = 632.8e-9\nwaist = 0.15e-3\ngrid = Grid(256, 256, 15e-6, 15e-6, dtype=torch.float64)\nx, y = grid.meshgrid()\nr2 = x.square() + y.square()\namplitude = torch.exp(-r2 / waist**2).to(torch.complex128)\nspectrum = Spectrum(\n    magnitude=0, band=Band(wavelength, 0.0, 1.0), samples=1, dtype=torch.float64\n)\nfield = Field(amplitude.unsqueeze(0), grid, spectrum)\nrayleigh_distance = torch.pi * waist**2 / wavelength\nprint(f\"Rayleigh distance: {float(rayleigh_distance):.4f} m\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Gaussian-beam spreading\n\nFor an amplitude proportional to \\(e^{-r^2/w_0^2}\\), theory predicts \\(w(z)=w_0\\sqrt{1+(z/z_R)^2}\\)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "distances = [0.04, 0.08, 0.16, 0.32]\nmeasured = []\nexpected = []\npropagated_fields = []\n\nfor distance in distances:\n    propagated = FFTPropagator(\n        propagation=\"fresnel\", distance=distance\n    ).apply(field)\n    intensity = propagated.intensity()[0]\n    x_out, y_out = propagated.grid.meshgrid()\n    measured_waist = torch.sqrt(\n        2 * ((x_out.square() + y_out.square()) * intensity).sum()\n        / intensity.sum()\n    )\n    expected_waist = waist * torch.sqrt(\n        torch.tensor(1 + (distance / rayleigh_distance) ** 2)\n    )\n    torch.testing.assert_close(measured_waist, expected_waist, rtol=3e-3, atol=0)\n    measured.append(float(measured_waist * 1e3))\n    expected.append(float(expected_waist * 1e3))\n    propagated_fields.append(propagated)\n\nplt.figure(figsize=(6, 4))\nplt.plot(distances, expected, \"k-\", label=\"Gaussian theory\")\nplt.plot(distances, measured, \"o\", label=\"Fiatlux FFT Fresnel\")\nplt.xlabel(\"Distance z [m]\")\nplt.ylabel(\"Beam radius w(z) [mm]\")\nplt.grid(True)\nplt.legend()\nplt.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Intensity and phase\n\nThe beam spreads while its phase acquires the expected quadratic curvature."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "fig, axes = plt.subplots(2, len(distances), figsize=(14, 6), constrained_layout=True)\nfor column, (distance, propagated) in enumerate(zip(distances, propagated_fields)):\n    extent = [\n        float(propagated.grid.x.min() * 1e3), float(propagated.grid.x.max() * 1e3),\n        float(propagated.grid.y.min() * 1e3), float(propagated.grid.y.max() * 1e3),\n    ]\n    axes[0, column].imshow(\n        propagated.intensity()[0].cpu(), origin=\"lower\", extent=extent\n    )\n    axes[1, column].imshow(\n        propagated.phase()[0].cpu(), origin=\"lower\", extent=extent,\n        cmap=\"twilight\", vmin=-torch.pi, vmax=torch.pi,\n    )\n    axes[0, column].set_title(f\"z = {distance:.2f} m\")\n    axes[0, column].set_ylabel(\"Intensity\")\n    axes[1, column].set_ylabel(\"Phase [rad]\")\n    axes[1, column].set_xlabel(\"x [mm]\")\nplt.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Fraunhofer limit and reversibility\n\nAt long distance, normalized Fresnel intensity converges to Fraunhofer. A sampled propagation by \\(+z\\) followed by \\(-z\\) returns the original complex field."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "far_distance = 10.0\nfresnel_far = FFTPropagator(\n    propagation=\"fresnel\", distance=far_distance\n).apply(field)\nfraunhofer = FFTPropagator(focal_length=far_distance).apply(field)\nfi = fresnel_far.intensity()[0] / fresnel_far.intensity()[0].max()\nff = fraunhofer.intensity()[0] / fraunhofer.intensity()[0].max()\nrelative_error = torch.linalg.vector_norm(fi - ff) / torch.linalg.vector_norm(ff)\nprint(f\"Far-field normalized-intensity error: {float(relative_error):.3e}\")\n\nforward = FFTPropagator(propagation=\"fresnel\", distance=0.25).apply(field)\nrecovered = FFTPropagator(propagation=\"fresnel\", distance=-0.25).apply(forward)\ntorch.testing.assert_close(\n    recovered.complex_amplitude, field.complex_amplitude, rtol=2e-12, atol=2e-12\n)\nrecovery_error = torch.linalg.vector_norm(\n    recovered.complex_amplitude - field.complex_amplitude\n) / torch.linalg.vector_norm(field.complex_amplitude)\nprint(f\"Forward/backward complex-field error: {float(recovery_error):.3e}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- validate Fresnel propagation against the analytical Gaussian-beam solution
- check beam radius, wavefront curvature and Gouy phase
- validate on-axis circular-aperture Fresnel diffraction
- quantify convergence of Fresnel intensity to Fraunhofer in the far field
- verify complex-field recovery after sampled forward and backward propagation
- add an executable physical-validation notebook with amplitude and phase images

## Physical references

For a Gaussian waist `w0`, the tests enforce:

```text
z_R = π w0² / λ
w(z) = w0 sqrt(1 + (z/z_R)²)
R(z) = z [1 + (z_R/z)²]
ψ(z) = atan(z/z_R)
```

For a circular aperture of radius `a`, the on-axis test uses:

```text
I(0,z) / I_input = 4 sin²[π a² / (2 λ z)]
```

## Tolerances

- Gaussian radius: 0.3%
- Gaussian phase curvature and Gouy phase: 0.02 rad
- circular-aperture on-axis intensity: 2%
- normalized Fresnel/Fraunhofer far-field difference: 0.5%
- forward/backward complex-field recovery: `2e-12`

The aperture tolerance includes discrete boundary sampling.

## Notebook

`tutorials/09_fresnel_physical_validation.ipynb` plots Gaussian intensity and phase at several distances, compares measured and analytical beam radii, evaluates the far-field limit, and reports forward/backward reconstruction error.

Local static validation passed. GitHub Actions performs the authoritative PyTorch test and clean-notebook execution.

Closes #77