### PR TITLE
Complete the Fresnel propagation tutorial

### DIFF
--- a/tutorials/09_fresnel_physical_validation.ipynb
+++ b/tutorials/09_fresnel_physical_validation.ipynb
@@ -63,6 +63,29 @@
       ],
       "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Choosing the propagator and its sampling\n\nMFT and FFT are numerical methods; Fraunhofer and Fresnel are physical regimes. Fiatlux supports all four combinations, and omitting `propagation` selects Fraunhofer.\n\n| Need | Recommended API | Sampling |\n|---|---|---|\n| Arbitrary focal or observation grid | `MFTPropagator(..., output_grid=...)` | You choose the output grid explicitly |\n| Fast monochromatic transform | `FFTPropagator(...)` | Fiatlux returns the natural conjugate grid |\n| Far-field or focal-plane propagation | default, or `propagation=\"fraunhofer\"` | Provide `focal_length` |\n| Finite-distance propagation | `propagation=\"fresnel\"` | Provide a non-zero `distance` |\n\nFor the FFT, the natural output spacing is \\(\\Delta x' = \\lambda |z|/(N_x\\Delta x)\\) and similarly along \\(y\\). MFT is preferable when downstream optics require a prescribed grid or when several wavelengths must share one output grid. The current FFT implementation intentionally accepts monochromatic fields only because its natural physical output grid depends on wavelength."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Differentiability\n\nPropagation stays inside PyTorch's computation graph. Here the intensity of an off-axis output pixel is differentiated with respect to every input phase sample."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "generator = torch.Generator().manual_seed(7)\ninput_phase = (\n    0.05 * torch.randn(amplitude.shape, generator=generator, dtype=torch.float64)\n).requires_grad_()\ntrainable_field = Field(\n    (amplitude * torch.exp(1j * input_phase)).unsqueeze(0), grid, spectrum\n)\ntrainable_output = FFTPropagator(\n    propagation=\"fresnel\", distance=0.08\n).apply(trainable_field)\ncenter_y = trainable_output.grid.ny // 2\ncenter_x = trainable_output.grid.nx // 2\nobjective = trainable_output.intensity()[0, center_y, center_x + 8]\nobjective.backward()\n\nassert input_phase.grad is not None\nassert torch.isfinite(input_phase.grad).all()\nassert torch.linalg.vector_norm(input_phase.grad) > 0\nprint(f\"Objective: {float(objective):.3e}\")\nprint(f\"Input-phase gradient norm: {float(torch.linalg.vector_norm(input_phase.grad)):.3e}\")\n\nplt.figure(figsize=(5, 4))\nplt.imshow(input_phase.grad.detach().cpu(), origin=\"lower\", cmap=\"RdBu_r\")\nplt.title(\"d output intensity / d input phase\")\nplt.colorbar(label=\"Gradient\")\nplt.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary

- turn the Fresnel validation notebook into an actionable propagation guide
- explain the independent MFT/FFT numerical-method and Fraunhofer/Fresnel physical-regime choices
- document natural FFT sampling and when an explicit MFT output grid is preferable
- demonstrate PyTorch autograd through Fresnel propagation with an input-phase gradient image
- keep angular-spectrum propagation explicitly out of scope

## Validation

- notebook JSON parses
- every Python cell parses
- all execution counts are null and no outputs are stored
- GitHub tutorial CI will execute the notebook from a clean kernel

Closes #73