### PR TITLE
Add analytical hexagonal segmented pupils

### DIFF
--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -57,6 +57,7 @@ from .optics.elements.deformable_mirror import (
     ZernikeBasis,
 )
 from .optics.elements.field_stop import ShanonFieldStop
+from .optics.elements.segmented_aperture import HexagonalSegmentedAperture
 from .optics.elements.mask import (
     Mask,
     CircularAperture,
@@ -122,6 +123,7 @@ __all__ = [
     "SquarePTTZonalBasis",
     "ZernikeBasis",
     "ShanonFieldStop",
+    "HexagonalSegmentedAperture",
     "Mask",
     "CircularAperture",
     "ArbitraryAperture",

--- a/fiatlux/optics/elements/__init__.py
+++ b/fiatlux/optics/elements/__init__.py
@@ -2,10 +2,12 @@ from .base import OpticalElement
 from .deformable_mirror import DeformableMirror
 from .field_stop import ShanonFieldStop
 from .mask import Mask
+from .segmented_aperture import HexagonalSegmentedAperture
 
 __all__ = [
     "OpticalElement",
     "DeformableMirror",
     "ShanonFieldStop",
     "Mask",
+    "HexagonalSegmentedAperture",
 ]

--- a/fiatlux/optics/elements/segmented_aperture.py
+++ b/fiatlux/optics/elements/segmented_aperture.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+
+import torch
+
+from fiatlux.config.registry import register_type
+from fiatlux.core.grid import Grid
+from fiatlux.optics.elements.mask import Mask
+
+
+AxialCoordinate = tuple[int, int]
+
+
+def _hexagonal_coordinates(rings: int) -> tuple[AxialCoordinate, ...]:
+    """Return axial coordinates ordered by ring, then lexicographically."""
+    coordinates = [
+        (q, r)
+        for q in range(-rings, rings + 1)
+        for r in range(-rings, rings + 1)
+        if max(abs(q), abs(r), abs(-q - r)) <= rings
+    ]
+    return tuple(
+        sorted(
+            coordinates,
+            key=lambda coordinate: (
+                max(abs(coordinate[0]), abs(coordinate[1]), abs(-sum(coordinate))),
+                coordinate,
+            ),
+        )
+    )
+
+
+@register_type("HexagonalSegmentedAperture")
+class HexagonalSegmentedAperture(Mask):
+    """Regular, flat-top hexagonal segmented aperture.
+
+    Parameters are expressed in metres. ``segment_circumradius`` is the
+    centre-to-corner distance of one reflective segment. ``gap`` is the
+    edge-to-edge separation between neighbouring segments. Segments are
+    identified by deterministic axial ``(q, r)`` coordinates.
+    """
+
+    def __init__(
+        self,
+        grid: Grid,
+        segment_circumradius: float,
+        rings: int,
+        *,
+        gap: float = 0.0,
+        inactive_segments: Iterable[AxialCoordinate] = (),
+        rotation: float = 0.0,
+    ):
+        if not math.isfinite(segment_circumradius) or segment_circumradius <= 0:
+            raise ValueError("segment_circumradius must be positive and finite.")
+        if not isinstance(rings, int) or isinstance(rings, bool) or rings < 0:
+            raise ValueError("rings must be a non-negative integer.")
+        if not math.isfinite(gap) or gap < 0:
+            raise ValueError("gap must be finite and non-negative.")
+        if not math.isfinite(rotation):
+            raise ValueError("rotation must be finite.")
+
+        all_coordinates = _hexagonal_coordinates(rings)
+        inactive = frozenset(tuple(coordinate) for coordinate in inactive_segments)
+        unknown = inactive.difference(all_coordinates)
+        if unknown:
+            raise ValueError(f"inactive_segments contains unknown coordinates: {sorted(unknown)}")
+
+        self.segment_circumradius = float(segment_circumradius)
+        self.rings = rings
+        self.gap = float(gap)
+        self.inactive_segments = inactive
+        self.rotation = float(rotation)
+        self.segment_coordinates = tuple(
+            coordinate for coordinate in all_coordinates if coordinate not in inactive
+        )
+        self.segment_index = torch.full(
+            grid.shape, -1, device=grid.device, dtype=torch.int64
+        )
+        super().__init__(grid=grid)
+
+    @property
+    def number_of_segments(self) -> int:
+        return len(self.segment_coordinates)
+
+    @property
+    def segment_centers(self) -> torch.Tensor:
+        """Physical ``(x, y)`` centres, shaped ``(number_of_segments, 2)``."""
+        effective_radius = self.segment_circumradius + self.gap / math.sqrt(3.0)
+        centers = torch.tensor(
+            [
+                (
+                    1.5 * effective_radius * q,
+                    math.sqrt(3.0) * effective_radius * (r + 0.5 * q),
+                )
+                for q, r in self.segment_coordinates
+            ],
+            device=self.grid.device,
+            dtype=self.grid.dtype,
+        )
+        angle = torch.as_tensor(
+            math.radians(self.rotation), device=self.grid.device, dtype=self.grid.dtype
+        )
+        cosine, sine = torch.cos(angle), torch.sin(angle)
+        x = cosine * centers[:, 0] - sine * centers[:, 1]
+        y = sine * centers[:, 0] + cosine * centers[:, 1]
+        return torch.stack((x, y), dim=-1)
+
+    def _build_transmission(self) -> None:
+        x, y = self.grid.meshgrid()
+        segment_index = torch.full(
+            self.grid.shape, -1, device=self.grid.device, dtype=torch.int64
+        )
+        radius = self.segment_circumradius
+        sqrt_three = math.sqrt(3.0)
+
+        for index, center in enumerate(self.segment_centers):
+            local_x = x - center[0]
+            local_y = y - center[1]
+            inside = (
+                (local_y.abs() <= 0.5 * sqrt_three * radius)
+                & ((sqrt_three * local_x + local_y).abs() <= sqrt_three * radius)
+                & ((sqrt_three * local_x - local_y).abs() <= sqrt_three * radius)
+            )
+            segment_index[inside] = index
+
+        self.segment_index = segment_index
+        self.transmission = (segment_index >= 0).to(dtype=self.grid.dtype)
+
+    def _build_opd(self) -> None:
+        self.opd = torch.zeros(
+            self.grid.shape, device=self.grid.device, dtype=self.grid.dtype
+        )
+
+    def index_of(self, coordinate: AxialCoordinate) -> int:
+        """Return the stable integer label associated with an active segment."""
+        try:
+            return self.segment_coordinates.index(tuple(coordinate))
+        except ValueError as error:
+            raise KeyError(f"No active segment at axial coordinate {coordinate}.") from error

--- a/tests/test_segmented_aperture.py
+++ b/tests/test_segmented_aperture.py
@@ -1,0 +1,75 @@
+import math
+
+import pytest
+import torch
+
+from fiatlux import Grid, HexagonalSegmentedAperture
+from fiatlux.core.spectrum import Band, Spectrum
+
+
+def _build(aperture: HexagonalSegmentedAperture) -> None:
+    aperture.build(Spectrum(0, Band(1e-6, 0.0, 1.0), 1, dtype=aperture.grid.dtype))
+
+
+def test_segment_count_and_axial_index_are_deterministic():
+    aperture = HexagonalSegmentedAperture(
+        Grid(401, 401, 0.01, 0.01, dtype=torch.float64),
+        segment_circumradius=0.2,
+        rings=2,
+    )
+
+    assert aperture.number_of_segments == 1 + 3 * 2 * (2 + 1)
+    assert aperture.segment_coordinates[0] == (0, 0)
+    assert aperture.index_of((0, 0)) == 0
+    assert aperture.segment_coordinates == tuple(aperture.segment_coordinates)
+
+
+def test_gap_and_inactive_segments_are_rendered_in_physical_coordinates():
+    grid = Grid(601, 601, 0.005, 0.005, dtype=torch.float64)
+    complete = HexagonalSegmentedAperture(
+        grid, 0.2, 1, gap=0.04
+    )
+    incomplete = HexagonalSegmentedAperture(
+        grid, 0.2, 1, gap=0.04, inactive_segments=[(1, 0)]
+    )
+    _build(complete)
+    _build(incomplete)
+
+    assert complete.number_of_segments == 7
+    assert incomplete.number_of_segments == 6
+    assert incomplete.transmission.sum() < complete.transmission.sum()
+    with pytest.raises(KeyError, match="No active segment"):
+        incomplete.index_of((1, 0))
+
+
+def test_sampled_area_matches_analytical_segment_area():
+    grid = Grid(801, 801, 0.004, 0.004, dtype=torch.float64)
+    radius = 0.2
+    aperture = HexagonalSegmentedAperture(grid, radius, 1, gap=0.02)
+    _build(aperture)
+
+    sampled_area = float(aperture.transmission.sum() * grid.dx * grid.dy)
+    expected_area = aperture.number_of_segments * 3 * math.sqrt(3) * radius**2 / 2
+    assert sampled_area == pytest.approx(expected_area, rel=0.015)
+
+
+def test_transmission_is_symmetric_and_uses_grid_dtype_and_device():
+    grid = Grid(401, 401, 0.01, 0.01, dtype=torch.float64)
+    aperture = HexagonalSegmentedAperture(grid, 0.2, 2, gap=0.02)
+    _build(aperture)
+
+    assert aperture.transmission.dtype == grid.dtype
+    assert aperture.transmission.device == grid.device
+    torch.testing.assert_close(aperture.transmission, torch.flip(aperture.transmission, (0,)))
+    torch.testing.assert_close(aperture.transmission, torch.flip(aperture.transmission, (1,)))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_segmented_aperture_is_device_aware_on_cuda():
+    grid = Grid(101, 101, 0.02, 0.02, device="cuda", dtype=torch.float32)
+    aperture = HexagonalSegmentedAperture(grid, 0.2, 1, gap=0.01)
+    _build(aperture)
+
+    assert aperture.segment_centers.device.type == "cuda"
+    assert aperture.transmission.device.type == "cuda"
+


### PR DESCRIPTION
## Summary

- add a public `HexagonalSegmentedAperture` generated entirely from physical coordinates
- define deterministic axial `(q, r)` segment coordinates and stable integer labels
- support physical inter-segment gaps, arbitrary rotations and inactive segments
- expose per-pixel `segment_index` and physical `segment_centers`
- preserve the grid dtype and device, including CUDA
- validate segment count, sampled collecting area, symmetry, gaps and inactive segments

## Geometry contract

`segment_circumradius` is the centre-to-corner distance of a reflective hexagon, in metres. `gap` is the edge-to-edge distance between adjacent reflective hexagons, also in metres. The implementation uses flat-top hexagons on a regular axial lattice.

This PR provides the segmented-M1 geometry engine. The ELT central obscuration, spiders and six M4 petals remain scoped to #76.

## Validation

Local static checks pass. GitHub Actions performs the authoritative PyTorch test suite on Python 3.10 and 3.12.

Closes #75