### PR TITLE
Add the analytical ELT/HARMONI pupil

### DIFF
--- a/examples/elt_harmoni_pupil_validation.ipynb
+++ b/examples/elt_harmoni_pupil_validation.ipynb
@@ -1,0 +1,74 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Analytical ELT/HARMONI pupil\n\nGenerate and inspect the ELT pupil without FITS files: 798 M1 segments, central obscuration, spiders and six projected M4 petals."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import matplotlib.pyplot as plt\nimport torch\n\nfrom fiatlux import ELTHarmoniPupil, FFTPropagator, Grid, PlaneWave, Spectrum\nfrom fiatlux.core.spectrum import Band\n\ntorch.set_default_dtype(torch.float64)\n\ngrid = Grid(601, 601, 0.08, 0.08, dtype=torch.float64)\nspectrum = Spectrum(\n    magnitude=0, band=Band(1.65e-6, 0.0, 1.0), samples=1, dtype=torch.float64\n)\npupil = ELTHarmoniPupil(\n    grid,\n    spider_width=0.5,\n    spider_angles=(0.0, 60.0, 120.0),\n    petal_gap=0.12,\n    petal_rotation=30.0,\n)\npupil.build(spectrum)\n\nprint(f\"Active M1 segments: {pupil.number_of_segments}\")\nprint(f\"Sampled collecting area: {float(pupil.transmission.sum() * grid.dx * grid.dy):.2f} m²\")\nassert pupil.number_of_segments == 798"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Transmission and labels\n\n`segment_index` and `petal_index` are `-1` outside the transmitted pupil. They can therefore be used directly to select a segment or an M4 petal for piston studies."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "extent = [float(grid.x.min()), float(grid.x.max()), float(grid.y.min()), float(grid.y.max())]\nfig, axes = plt.subplots(1, 3, figsize=(16, 5), constrained_layout=True)\nimages = [pupil.transmission, pupil.segment_index, pupil.petal_index]\ntitles = [\"Transmission\", \"M1 segment index\", \"Projected M4 petal index\"]\ncmaps = [\"gray\", \"turbo\", \"tab10\"]\nfor axis, image, title, cmap in zip(axes, images, titles, cmaps):\n    axis.imshow(image.cpu(), origin=\"lower\", extent=extent, cmap=cmap)\n    axis.set(title=title, xlabel=\"x [m]\", ylabel=\"y [m]\")\n    axis.set_aspect(\"equal\")\nplt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Select petals and segments"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "petal_areas = torch.stack([\n    pupil.petal_mask(index).sum() * grid.dx * grid.dy for index in range(6)\n])\ncoordinate = pupil.segment_coordinates[100]\nselected_segment = pupil.segment_mask(coordinate)\nprint(\"Petal areas [m²]:\", petal_areas.tolist())\nprint(f\"Selected segment {coordinate}: {int(selected_segment.sum())} pixels\")\nassert torch.all(petal_areas > 0)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Fraunhofer PSF\n\nThe analytical pupil is a normal Fiatlux mask and composes directly with the default Fraunhofer propagator."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "entrance = PlaneWave(spectrum).generate_field(grid)\nfocal = FFTPropagator(focal_length=1.0).apply(pupil.apply(entrance))\npsf = focal.intensity()[0]\npsf = psf / psf.max()\nfocal_extent = [\n    float(focal.grid.x.min() * 1e6), float(focal.grid.x.max() * 1e6),\n    float(focal.grid.y.min() * 1e6), float(focal.grid.y.max() * 1e6),\n]\nplt.figure(figsize=(6, 5))\nplt.imshow(torch.log10(psf.clamp_min(1e-10)).cpu(), origin=\"lower\", extent=focal_extent, cmap=\"inferno\", vmin=-8, vmax=0)\nplt.xlim(-0.5, 0.5)\nplt.ylim(-0.5, 0.5)\nplt.xlabel(\"x [µm]\")\nplt.ylabel(\"y [µm]\")\nplt.title(\"ELT/HARMONI Fraunhofer PSF [log10]\")\nplt.colorbar(label=\"log10 normalized intensity\")\nplt.show()"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+    "language_info": {"name": "python", "version": "3.12"}
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -57,7 +57,10 @@ from .optics.elements.deformable_mirror import (
     ZernikeBasis,
 )
 from .optics.elements.field_stop import ShanonFieldStop
-from .optics.elements.segmented_aperture import HexagonalSegmentedAperture
+from .optics.elements.segmented_aperture import (
+    ELTHarmoniPupil,
+    HexagonalSegmentedAperture,
+)
 from .optics.elements.mask import (
     Mask,
     CircularAperture,
@@ -124,6 +127,7 @@ __all__ = [
     "ZernikeBasis",
     "ShanonFieldStop",
     "HexagonalSegmentedAperture",
+    "ELTHarmoniPupil",
     "Mask",
     "CircularAperture",
     "ArbitraryAperture",

--- a/fiatlux/optics/elements/__init__.py
+++ b/fiatlux/optics/elements/__init__.py
@@ -2,7 +2,7 @@ from .base import OpticalElement
 from .deformable_mirror import DeformableMirror
 from .field_stop import ShanonFieldStop
 from .mask import Mask
-from .segmented_aperture import HexagonalSegmentedAperture
+from .segmented_aperture import ELTHarmoniPupil, HexagonalSegmentedAperture
 
 __all__ = [
     "OpticalElement",
@@ -10,4 +10,5 @@ __all__ = [
     "ShanonFieldStop",
     "Mask",
     "HexagonalSegmentedAperture",
+    "ELTHarmoniPupil",
 ]

--- a/fiatlux/optics/elements/segmented_aperture.py
+++ b/fiatlux/optics/elements/segmented_aperture.py
@@ -51,6 +51,7 @@ class HexagonalSegmentedAperture(Mask):
         gap: float = 0.0,
         inactive_segments: Iterable[AxialCoordinate] = (),
         rotation: float = 0.0,
+        center: tuple[float, float] = (0.0, 0.0),
     ):
         if not math.isfinite(segment_circumradius) or segment_circumradius <= 0:
             raise ValueError("segment_circumradius must be positive and finite.")
@@ -60,6 +61,8 @@ class HexagonalSegmentedAperture(Mask):
             raise ValueError("gap must be finite and non-negative.")
         if not math.isfinite(rotation):
             raise ValueError("rotation must be finite.")
+        if len(center) != 2 or not all(math.isfinite(value) for value in center):
+            raise ValueError("center must contain two finite coordinates in metres.")
 
         all_coordinates = _hexagonal_coordinates(rings)
         inactive = frozenset(tuple(coordinate) for coordinate in inactive_segments)
@@ -72,6 +75,7 @@ class HexagonalSegmentedAperture(Mask):
         self.gap = float(gap)
         self.inactive_segments = inactive
         self.rotation = float(rotation)
+        self.center = (float(center[0]), float(center[1]))
         self.segment_coordinates = tuple(
             coordinate for coordinate in all_coordinates if coordinate not in inactive
         )
@@ -103,8 +107,8 @@ class HexagonalSegmentedAperture(Mask):
             math.radians(self.rotation), device=self.grid.device, dtype=self.grid.dtype
         )
         cosine, sine = torch.cos(angle), torch.sin(angle)
-        x = cosine * centers[:, 0] - sine * centers[:, 1]
-        y = sine * centers[:, 0] + cosine * centers[:, 1]
+        x = cosine * centers[:, 0] - sine * centers[:, 1] + self.center[0]
+        y = sine * centers[:, 0] + cosine * centers[:, 1] + self.center[1]
         return torch.stack((x, y), dim=-1)
 
     def _build_transmission(self) -> None:
@@ -139,3 +143,166 @@ class HexagonalSegmentedAperture(Mask):
             return self.segment_coordinates.index(tuple(coordinate))
         except ValueError as error:
             raise KeyError(f"No active segment at axial coordinate {coordinate}.") from error
+
+    def segment_mask(self, coordinate: AxialCoordinate) -> torch.Tensor:
+        """Boolean pixel support of one active segment after :meth:`build`."""
+        return self.segment_index == self.index_of(coordinate)
+
+
+def _rotate_axial(coordinate: AxialCoordinate) -> AxialCoordinate:
+    q, r = coordinate
+    return -r, q + r
+
+
+def _axial_orbit(coordinate: AxialCoordinate) -> tuple[AxialCoordinate, ...]:
+    orbit = []
+    current = coordinate
+    for _ in range(6):
+        orbit.append(current)
+        current = _rotate_axial(current)
+    return tuple(sorted(set(orbit)))
+
+
+def _elt_coordinates(
+    segment_circumradius: float,
+    gap: float,
+    inner_radius: float,
+    segment_count: int,
+) -> tuple[AxialCoordinate, ...]:
+    """Select complete sixfold axial orbits nearest the ELT annulus."""
+    if segment_count <= 0 or segment_count % 6:
+        raise ValueError("segment_count must be a positive multiple of six.")
+    effective_radius = segment_circumradius + gap / math.sqrt(3.0)
+    candidates = _hexagonal_coordinates(24)
+    orbits: dict[tuple[AxialCoordinate, ...], float] = {}
+    for coordinate in candidates:
+        if coordinate == (0, 0):
+            continue
+        orbit = _axial_orbit(coordinate)
+        q, r = coordinate
+        x = 1.5 * effective_radius * q
+        y = math.sqrt(3.0) * effective_radius * (r + 0.5 * q)
+        radius = math.hypot(x, y)
+        if radius >= inner_radius - segment_circumradius:
+            orbits[orbit] = radius
+    selected = sorted(orbits, key=lambda orbit: (orbits[orbit], orbit))[
+        : segment_count // 6
+    ]
+    return tuple(sorted(coordinate for orbit in selected for coordinate in orbit))
+
+
+@register_type("ELTHarmoniPupil")
+class ELTHarmoniPupil(HexagonalSegmentedAperture):
+    """Self-contained analytical ELT pupil for HARMONI simulations.
+
+    Lengths are metres in the entrance-pupil plane. Spider and M4 inter-petal
+    widths are projected widths in that plane. Defaults describe a 37 m filled
+    M1 annulus made from 798 reflective 1.45 m corner-to-corner segments.
+    """
+
+    def __init__(
+        self,
+        grid: Grid,
+        *,
+        outer_radius: float = 18.5,
+        central_obscuration_radius: float = 5.5,
+        segment_circumradius: float = 0.725,
+        segment_gap: float = 0.004,
+        segment_count: int = 798,
+        spider_width: float = 0.5,
+        spider_angles: tuple[float, ...] = (0.0, 60.0, 120.0),
+        petal_gap: float = 0.0,
+        petal_rotation: float = 0.0,
+        inactive_segments: Iterable[AxialCoordinate] = (),
+        rotation: float = 0.0,
+        center: tuple[float, float] = (0.0, 0.0),
+    ):
+        for name, value in (
+            ("outer_radius", outer_radius),
+            ("central_obscuration_radius", central_obscuration_radius),
+            ("spider_width", spider_width),
+            ("petal_gap", petal_gap),
+        ):
+            if not math.isfinite(value) or value < 0:
+                raise ValueError(f"{name} must be finite and non-negative.")
+        if central_obscuration_radius >= outer_radius:
+            raise ValueError("central_obscuration_radius must be smaller than outer_radius.")
+        if not spider_angles or not all(math.isfinite(angle) for angle in spider_angles):
+            raise ValueError("spider_angles must contain finite angles in degrees.")
+        if not math.isfinite(petal_rotation):
+            raise ValueError("petal_rotation must be finite.")
+
+        active = _elt_coordinates(
+            segment_circumradius,
+            segment_gap,
+            central_obscuration_radius,
+            segment_count,
+        )
+        all_coordinates = set(_hexagonal_coordinates(24))
+        inactive = all_coordinates.difference(active).union(
+            tuple(coordinate) for coordinate in inactive_segments
+        )
+        self.outer_radius = float(outer_radius)
+        self.central_obscuration_radius = float(central_obscuration_radius)
+        self.spider_width = float(spider_width)
+        self.spider_angles = tuple(float(angle) for angle in spider_angles)
+        self.petal_gap = float(petal_gap)
+        self.petal_rotation = float(petal_rotation)
+        self.petal_index = torch.full(
+            grid.shape, -1, device=grid.device, dtype=torch.int64
+        )
+        super().__init__(
+            grid,
+            segment_circumradius,
+            24,
+            gap=segment_gap,
+            inactive_segments=inactive,
+            rotation=rotation,
+            center=center,
+        )
+
+    def _build_transmission(self) -> None:
+        super()._build_transmission()
+        x, y = self.grid.meshgrid()
+        x = x - self.center[0]
+        y = y - self.center[1]
+        angle = math.radians(self.rotation)
+        local_x = math.cos(angle) * x + math.sin(angle) * y
+        local_y = -math.sin(angle) * x + math.cos(angle) * y
+        radius = torch.sqrt(local_x.square() + local_y.square())
+        support = (radius >= self.central_obscuration_radius) & (
+            radius <= self.outer_radius
+        )
+
+        if self.spider_width > 0:
+            for spider_angle in self.spider_angles:
+                theta = math.radians(spider_angle)
+                perpendicular_distance = (
+                    -math.sin(theta) * local_x + math.cos(theta) * local_y
+                ).abs()
+                support &= perpendicular_distance > 0.5 * self.spider_width
+
+        polar_angle = torch.remainder(
+            torch.atan2(local_y, local_x) - math.radians(self.petal_rotation),
+            2 * math.pi,
+        )
+        petal_index = torch.floor(polar_angle / (math.pi / 3)).to(torch.int64)
+        if self.petal_gap > 0:
+            for boundary in range(3):
+                theta = math.radians(self.petal_rotation) + boundary * math.pi / 3
+                distance = (-math.sin(theta) * local_x + math.cos(theta) * local_y).abs()
+                support &= distance > 0.5 * self.petal_gap
+
+        self.transmission *= support.to(self.grid.dtype)
+        self.segment_index = torch.where(
+            support, self.segment_index, torch.full_like(self.segment_index, -1)
+        )
+        self.petal_index = torch.where(
+            self.transmission > 0, petal_index, torch.full_like(petal_index, -1)
+        )
+
+    def petal_mask(self, index: int) -> torch.Tensor:
+        """Boolean pixel support for one of the six M4 petals."""
+        if not isinstance(index, int) or isinstance(index, bool) or not 0 <= index < 6:
+            raise ValueError("petal index must be an integer from 0 to 5.")
+        return self.petal_index == index

--- a/tests/test_elt_harmoni_pupil.py
+++ b/tests/test_elt_harmoni_pupil.py
@@ -1,0 +1,62 @@
+import math
+
+import torch
+
+from fiatlux import ELTHarmoniPupil, Grid
+from fiatlux.core.spectrum import Band, Spectrum
+
+
+def _build(pupil: ELTHarmoniPupil) -> None:
+    pupil.build(Spectrum(0, Band(1e-6, 0.0, 1.0), 1, dtype=pupil.grid.dtype))
+
+
+def test_default_elt_pupil_has_798_segments_and_six_petals():
+    grid = Grid(401, 401, 0.1, 0.1, dtype=torch.float64)
+    pupil = ELTHarmoniPupil(grid, spider_width=0.0, petal_gap=0.02)
+    _build(pupil)
+
+    assert pupil.number_of_segments == 798
+    active_petals = torch.unique(pupil.petal_index[pupil.petal_index >= 0])
+    torch.testing.assert_close(active_petals, torch.arange(6))
+
+
+def test_obscuration_spiders_and_petal_gaps_block_expected_points():
+    grid = Grid(501, 501, 0.1, 0.1, dtype=torch.float64)
+    pupil = ELTHarmoniPupil(
+        grid,
+        central_obscuration_radius=5.5,
+        spider_width=0.4,
+        spider_angles=(0.0,),
+        petal_gap=0.2,
+        petal_rotation=30.0,
+    )
+    _build(pupil)
+    center = grid.nx // 2
+
+    assert pupil.transmission[center, center] == 0
+    assert torch.all(pupil.transmission[center, :] == 0)
+    assert torch.all(pupil.segment_index[pupil.transmission == 0] == -1)
+    assert torch.all(pupil.petal_index[pupil.transmission == 0] == -1)
+
+
+def test_center_moves_the_obscuration_and_rotation_moves_segment_centers():
+    grid = Grid(301, 301, 0.2, 0.2, dtype=torch.float64)
+    reference = ELTHarmoniPupil(grid, center=(0.0, 0.0), rotation=0.0)
+    transformed = ELTHarmoniPupil(grid, center=(1.0, -0.6), rotation=30.0)
+
+    reference_center = reference.segment_centers[0]
+    transformed_center = transformed.segment_centers[0]
+    expected_x = math.cos(math.pi / 6) * reference_center[0] - math.sin(math.pi / 6) * reference_center[1] + 1.0
+    expected_y = math.sin(math.pi / 6) * reference_center[0] + math.cos(math.pi / 6) * reference_center[1] - 0.6
+    torch.testing.assert_close(transformed_center, torch.stack((expected_x, expected_y)))
+
+
+def test_segment_and_petal_masks_select_only_transmitted_pixels():
+    grid = Grid(301, 301, 0.15, 0.15, dtype=torch.float64)
+    pupil = ELTHarmoniPupil(grid, spider_width=0.2, petal_gap=0.1)
+    _build(pupil)
+
+    coordinate = pupil.segment_coordinates[100]
+    assert torch.all(pupil.segment_mask(coordinate) <= (pupil.transmission > 0))
+    for index in range(6):
+        assert torch.all(pupil.petal_mask(index) <= (pupil.transmission > 0))


### PR DESCRIPTION
## Summary

- add a public `ELTHarmoniPupil` with no FITS dependency
- generate exactly 798 active M1 segments in sixfold-symmetric axial orbits
- apply the 37 m filled aperture and 11 m central obscuration
- add configurable projected spider widths and angles
- label six projected M4 petals with configurable inter-petal gaps
- support global pupil rotation and physical decentering
- expose segment and petal masks for piston studies
- add a visual notebook showing transmission, labels and the Fraunhofer PSF

## Units and conventions

All lengths are metres in the entrance-pupil plane. Spider and M4-gap widths are projected widths in that plane. Angles are degrees. The defaults use 1.45 m corner-to-corner M1 segments and a 4 mm segment gap.

The exact pixel-level comparison against an authoritative HARMONI pupil remains part of #82.

## Validation

- static Python and notebook parsing passes
- notebook contains no stored outputs
- tests cover the 798-segment count, six petal labels, obscuration, spiders, gaps, centering, rotation and selection masks
- GitHub Actions performs the authoritative PyTorch execution

Closes #76