### PR TITLE
Validate the analytical ELT/HARMONI pupil

### DIFF
--- a/examples/elt_harmoni_pupil_validation.ipynb
+++ b/examples/elt_harmoni_pupil_validation.ipynb
@@ -13,7 +13,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import matplotlib.pyplot as plt\nimport torch\n\nfrom fiatlux import ELTHarmoniPupil, FFTPropagator, Grid, PlaneWave, Spectrum\nfrom fiatlux.core.spectrum import Band\n\ntorch.set_default_dtype(torch.float64)\n\ngrid = Grid(601, 601, 0.08, 0.08, dtype=torch.float64)\nspectrum = Spectrum(\n    magnitude=0, band=Band(1.65e-6, 0.0, 1.0), samples=1, dtype=torch.float64\n)\npupil = ELTHarmoniPupil(\n    grid,\n    spider_width=0.5,\n    spider_angles=(0.0, 60.0, 120.0),\n    petal_gap=0.12,\n    petal_rotation=30.0,\n)\npupil.build(spectrum)\n\nprint(f\"Active M1 segments: {pupil.number_of_segments}\")\nprint(f\"Sampled collecting area: {float(pupil.transmission.sum() * grid.dx * grid.dy):.2f} m²\")\nassert pupil.number_of_segments == 798"
+        "import matplotlib.pyplot as plt\nimport torch\n\nfrom fiatlux import ELTHarmoniPupil, FFTPropagator, Grid, PlaneWave, Spectrum\nfrom fiatlux.core.spectrum import Band\n\ntorch.set_default_dtype(torch.float64)\n\ngrid = Grid(601, 601, 0.08, 0.08, dtype=torch.float64)\nspectrum = Spectrum(\n    magnitude=0, band=Band(1.65e-6, 0.0, 1.0), samples=1, dtype=torch.float64\n)\npupil = ELTHarmoniPupil(\n    grid,\n    spider_width=0.5,\n    spider_angles=(0.0, 60.0, 120.0),\n    petal_gap=0.12,\n    petal_rotation=0.0,  # Petal boundaries aligned with the spiders.\n)\npupil.build(spectrum)\n\nprint(f\"Active M1 segments: {pupil.number_of_segments}\")\nprint(f\"Sampled collecting area: {float(pupil.transmission.sum() * grid.dx * grid.dy):.2f} m²\")\nassert pupil.number_of_segments == 798"
       ]
     },
     {

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -41,6 +41,7 @@ from .optics.propagator import (
 from .optics.detector import Detector
 from .optics.adc import ADCDispersionModel
 from .optics.atmosphere import AtmosphereModel, KolmogorovAtmosphereModel, NCPAModel
+from .optics.pupil_validation import PupilComparison, compare_pupil_masks
 
 # =========================
 # Optical elements
@@ -116,6 +117,8 @@ __all__ = [
     "AtmosphereModel",
     "KolmogorovAtmosphereModel",
     "NCPAModel",
+    "PupilComparison",
+    "compare_pupil_masks",
     # Elements
     "OpticalElement",
     "DeformableMirror",

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -8,6 +8,7 @@ from .propagator import (
     PropagationSamplingError,
     Propagator,
 )
+from .pupil_validation import PupilComparison, compare_pupil_masks
 
 __all__ = [
     "ADCDispersionModel",
@@ -20,4 +21,6 @@ __all__ = [
     "PropagationRegime",
     "PropagationSamplingError",
     "Propagator",
+    "PupilComparison",
+    "compare_pupil_masks",
 ]

--- a/fiatlux/optics/pupil_validation.py
+++ b/fiatlux/optics/pupil_validation.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class PupilComparison:
+    """Dimensionless overlap metrics and physical areas for two pupil masks."""
+
+    intersection_over_union: float
+    dice: float
+    analytical_area: float
+    reference_area: float
+    relative_area_error: float
+    false_positive_fraction: float
+    false_negative_fraction: float
+
+
+def compare_pupil_masks(
+    analytical: torch.Tensor,
+    reference: torch.Tensor,
+    *,
+    pixel_area: float,
+    threshold: float = 0.5,
+) -> PupilComparison:
+    """Compare sampled pupil supports, including an optionally loaded FITS mask.
+
+    Both tensors must describe the same registered sampling. Floating masks are
+    converted to support masks using ``value > threshold``. ``pixel_area`` is
+    in square metres, so returned areas are in square metres.
+    """
+    if analytical.ndim != 2 or reference.ndim != 2:
+        raise ValueError("Pupil masks must both be two-dimensional.")
+    if analytical.shape != reference.shape:
+        raise ValueError(
+            f"Pupil masks must have identical shapes; got {tuple(analytical.shape)} "
+            f"and {tuple(reference.shape)}."
+        )
+    if not math.isfinite(pixel_area) or pixel_area <= 0:
+        raise ValueError("pixel_area must be positive and finite.")
+    if not math.isfinite(threshold):
+        raise ValueError("threshold must be finite.")
+
+    analytical_support = analytical > threshold
+    reference_support = reference.to(analytical.device) > threshold
+    intersection = torch.count_nonzero(analytical_support & reference_support).item()
+    union = torch.count_nonzero(analytical_support | reference_support).item()
+    analytical_count = torch.count_nonzero(analytical_support).item()
+    reference_count = torch.count_nonzero(reference_support).item()
+    if union == 0 or analytical_count + reference_count == 0 or reference_count == 0:
+        raise ValueError("The comparison requires a non-empty reference and union.")
+
+    analytical_area = analytical_count * pixel_area
+    reference_area = reference_count * pixel_area
+    false_positive = torch.count_nonzero(
+        analytical_support & ~reference_support
+    ).item()
+    false_negative = torch.count_nonzero(
+        ~analytical_support & reference_support
+    ).item()
+    return PupilComparison(
+        intersection_over_union=intersection / union,
+        dice=2 * intersection / (analytical_count + reference_count),
+        analytical_area=analytical_area,
+        reference_area=reference_area,
+        relative_area_error=(analytical_area - reference_area) / reference_area,
+        false_positive_fraction=false_positive / reference_count,
+        false_negative_fraction=false_negative / reference_count,
+    )

--- a/tests/test_pupil_validation.py
+++ b/tests/test_pupil_validation.py
@@ -1,0 +1,103 @@
+import math
+
+import pytest
+import torch
+
+from fiatlux import ELTHarmoniPupil, Grid, compare_pupil_masks
+from fiatlux.core.spectrum import Band, Spectrum
+
+
+def _build(pupil: ELTHarmoniPupil) -> None:
+    pupil.build(Spectrum(0, Band(1e-6, 0.0, 1.0), 1, dtype=pupil.grid.dtype))
+
+
+def test_default_pupil_is_symmetric_and_has_plausible_collecting_area():
+    grid = Grid(401, 401, 0.12, 0.12, dtype=torch.float64)
+    pupil = ELTHarmoniPupil(grid, spider_width=0.0, petal_gap=0.0)
+    _build(pupil)
+
+    sampled_area = float(pupil.transmission.sum() * grid.dx * grid.dy)
+    annular_area = math.pi * (
+        pupil.outer_radius**2 - pupil.central_obscuration_radius**2
+    )
+    assert pupil.number_of_segments == 798
+    assert sampled_area / annular_area == pytest.approx(1.0, rel=0.08)
+    torch.testing.assert_close(pupil.transmission, torch.flip(pupil.transmission, (0,)))
+    torch.testing.assert_close(pupil.transmission, torch.flip(pupil.transmission, (1,)))
+
+
+def test_collecting_area_converges_with_sampling():
+    spacings = (0.48, 0.24, 0.12)
+    sizes = (101, 201, 401)
+    areas = []
+    for size, spacing in zip(sizes, spacings):
+        pupil = ELTHarmoniPupil(
+            Grid(size, size, spacing, spacing, dtype=torch.float64),
+            spider_width=0.0,
+            petal_gap=0.0,
+        )
+        _build(pupil)
+        sampled_area = float(pupil.transmission.sum() * spacing**2)
+        areas.append(sampled_area)
+
+    coarse_change = abs(areas[1] - areas[0])
+    fine_change = abs(areas[2] - areas[1])
+    assert fine_change < coarse_change
+    assert fine_change / areas[2] < 0.01
+
+
+def test_reference_comparison_reports_known_overlap_metrics():
+    reference = torch.tensor([[1, 1, 0], [1, 0, 0]], dtype=torch.float64)
+    analytical = torch.tensor([[1, 0, 1], [1, 0, 0]], dtype=torch.float32)
+
+    comparison = compare_pupil_masks(
+        analytical, reference, pixel_area=0.25
+    )
+
+    assert comparison.intersection_over_union == pytest.approx(0.5)
+    assert comparison.dice == pytest.approx(2 / 3)
+    assert comparison.analytical_area == pytest.approx(0.75)
+    assert comparison.reference_area == pytest.approx(0.75)
+    assert comparison.relative_area_error == pytest.approx(0.0)
+    assert comparison.false_positive_fraction == pytest.approx(1 / 3)
+    assert comparison.false_negative_fraction == pytest.approx(1 / 3)
+
+
+def test_reference_comparison_validates_registration_and_empty_masks():
+    with pytest.raises(ValueError, match="identical shapes"):
+        compare_pupil_masks(torch.ones(2, 2), torch.ones(3, 3), pixel_area=1.0)
+    with pytest.raises(ValueError, match="non-empty"):
+        compare_pupil_masks(torch.zeros(2, 2), torch.zeros(2, 2), pixel_area=1.0)
+
+
+def test_m4_petal_boundaries_align_with_spiders():
+    grid = Grid(301, 301, 0.16, 0.16, dtype=torch.float64)
+    common = dict(
+        grid=grid,
+        central_obscuration_radius=5.5,
+        spider_angles=(0.0, 60.0, 120.0),
+    )
+    spider_only = ELTHarmoniPupil(
+        **common, spider_width=0.24, petal_gap=0.0
+    )
+    petal_only = ELTHarmoniPupil(
+        **common, spider_width=0.0, petal_gap=0.24, petal_rotation=0.0
+    )
+    _build(spider_only)
+    _build(petal_only)
+
+    torch.testing.assert_close(spider_only.transmission, petal_only.transmission)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_elt_pupil_and_reference_comparison_run_on_cuda():
+    grid = Grid(201, 201, 0.24, 0.24, device="cuda", dtype=torch.float32)
+    pupil = ELTHarmoniPupil(grid)
+    _build(pupil)
+    comparison = compare_pupil_masks(
+        pupil.transmission, pupil.transmission.clone(), pixel_area=grid.dx * grid.dy
+    )
+
+    assert comparison.intersection_over_union == 1.0
+    assert pupil.transmission.dtype == torch.float32
+    assert pupil.transmission.device.type == "cuda"


### PR DESCRIPTION
## Summary

- validate the 798-segment analytical pupil without external data
- test symmetry, collecting area and numerical convergence with sampling
- cover ELT pupil dtype/device behavior on CUDA when available
- add a public comparison helper for optional registered reference masks
- report IoU, Dice, physical areas, area bias, false positives and false negatives

## Optional FITS workflow

The core API accepts tensors and has no Astropy dependency. A local authoritative FITS mask can be loaded with `astropy.io.fits`, registered on the analytical grid, converted to a tensor, then passed to:

```python
comparison = compare_pupil_masks(
    analytical=pupil.transmission,
    reference=reference_mask,
    pixel_area=grid.dx * grid.dy,
)
```

The reference file is never required by CI or committed to the repository.

## Validation

Local static checks pass. The test sampling sequence uses 101², 201² and 401² grids and checks that the collecting-area estimate stabilizes as sampling increases.

Closes #82