### PR TITLE
Add an optional FATMOSS integration layer

### DIFF
--- a/docs/fatmoss.md
+++ b/docs/fatmoss.md
@@ -1,0 +1,53 @@
+# Optional FATMOSS integration
+
+Fiatlux integrates [FATMOSS](https://github.com/EjjeSynho/FATMOSS) through a
+narrow optional adapter. Importing and using core Fiatlux does not import or
+require FATMOSS.
+
+The adapter currently targets the upstream `main` API at commit
+`12e608686dfc69955f722e2ee62455fcd3e32d2e`, in particular
+`PhaseScreensGenerator(...)` and `GetScreenByTimestep(timestep)`.
+
+## Installation
+
+FATMOSS does not currently publish an installable Python package. Clone it and
+make its source directory importable:
+
+```bash
+git clone https://github.com/EjjeSynho/FATMOSS.git
+export PYTHONPATH="$PWD/FATMOSS:$PYTHONPATH"
+```
+
+The upstream `settings.json` controls NumPy/CuPy execution and must remain next
+to the FATMOSS source files. Install its dependencies according to its README.
+
+## Constructing the adapter
+
+```python
+from fiatlux import FatmossAtmosphereModel, Grid
+
+grid = Grid(256, 256, 0.04, 0.04)
+model = FatmossAtmosphereModel.create(
+    grid,
+    time_step=1e-3,
+    batch_size=100,
+    n_cascades=3,
+    seed=42,
+)
+```
+
+Layers are added through `model.backend` using FATMOSS' current `Layer` API.
+The dedicated frozen-flow and multilayer issues will wrap that construction in
+Fiatlux-owned physical layer configurations.
+
+## Conventions
+
+- `Grid.dx`, `Grid.dy` and generator diameter `D`: metres.
+- `time_step`: seconds.
+- `reference_wavelength`: metres in Fiatlux; FATMOSS currently uses 500 nm.
+- upstream screens: nanometres of OPD in `(x, y)` order.
+- `sample_opd()` output: metres of OPD in Fiatlux `(ny, nx)` order.
+- the FATMOSS seed owns temporal reproducibility; a PyTorch generator is not
+  accepted by `sample_opd()`.
+
+No rescaling to a target RMS or modification of the FATMOSS PSD is performed.

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -42,6 +42,7 @@ from .optics.detector import Detector
 from .optics.adc import ADCDispersionModel
 from .optics.atmosphere import AtmosphereModel, KolmogorovAtmosphereModel, NCPAModel
 from .optics.pupil_validation import PupilComparison, compare_pupil_masks
+from .optics.fatmoss import FatmossAtmosphereModel, FatmossUnavailableError
 
 # =========================
 # Optical elements
@@ -119,6 +120,8 @@ __all__ = [
     "NCPAModel",
     "PupilComparison",
     "compare_pupil_masks",
+    "FatmossAtmosphereModel",
+    "FatmossUnavailableError",
     # Elements
     "OpticalElement",
     "DeformableMirror",

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -9,6 +9,7 @@ from .propagator import (
     Propagator,
 )
 from .pupil_validation import PupilComparison, compare_pupil_masks
+from .fatmoss import FatmossAtmosphereModel, FatmossUnavailableError
 
 __all__ = [
     "ADCDispersionModel",
@@ -23,4 +24,6 @@ __all__ = [
     "Propagator",
     "PupilComparison",
     "compare_pupil_masks",
+    "FatmossAtmosphereModel",
+    "FatmossUnavailableError",
 ]

--- a/fiatlux/optics/fatmoss.py
+++ b/fiatlux/optics/fatmoss.py
@@ -1,0 +1,163 @@
+"""Optional bridge between Fiatlux fields and the external FATMOSS backend."""
+
+from __future__ import annotations
+
+import importlib
+import math
+from typing import Any, Literal, Protocol
+
+import torch
+
+from fiatlux.core.grid import Grid
+
+
+class FatmossUnavailableError(ImportError):
+    """FATMOSS was requested but its source modules cannot be imported."""
+
+
+class FatmossBackend(Protocol):
+    """Narrow subset of FATMOSS consumed by Fiatlux."""
+
+    def GetScreenByTimestep(self, timestep: int) -> Any: ...
+
+
+class FatmossAtmosphereModel:
+    """Expose sequential FATMOSS screens as Fiatlux OPD screens.
+
+    FATMOSS currently returns optical-path screens in nanometres and stores
+    spatial arrays in ``(x, y)`` order. Fiatlux uses metres and ``(ny, nx)``.
+    Both conventions are explicit and configurable here so no unit or axis
+    conversion is hidden in :class:`~fiatlux.optics.elements.mask.Atmosphere`.
+    """
+
+    def __init__(
+        self,
+        grid: Grid,
+        backend: FatmossBackend,
+        *,
+        reference_wavelength: float = 500e-9,
+        screen_unit: Literal["nm", "m"] = "nm",
+        source_axes: Literal["xy", "yx"] = "xy",
+        initial_timestep: int = 0,
+    ) -> None:
+        if not math.isfinite(reference_wavelength) or reference_wavelength <= 0:
+            raise ValueError("reference_wavelength must be positive and finite.")
+        if screen_unit not in ("nm", "m"):
+            raise ValueError("screen_unit must be 'nm' or 'm'.")
+        if source_axes not in ("xy", "yx"):
+            raise ValueError("source_axes must be 'xy' or 'yx'.")
+        if (
+            not isinstance(initial_timestep, int)
+            or isinstance(initial_timestep, bool)
+            or initial_timestep < 0
+        ):
+            raise ValueError("initial_timestep must be a non-negative integer.")
+        if not callable(getattr(backend, "GetScreenByTimestep", None)):
+            raise TypeError("FATMOSS backend must define GetScreenByTimestep(timestep).")
+
+        self.grid = grid
+        self.backend = backend
+        self.reference_wavelength = float(reference_wavelength)
+        self.screen_unit = screen_unit
+        self.source_axes = source_axes
+        self.timestep = initial_timestep
+        self.dtype = grid.dtype
+        # ``Atmosphere`` forwards this value to ``sample_opd``. FATMOSS owns
+        # its seeded RNG, so no independent torch.Generator is advertised.
+        self.generator = None
+
+    @classmethod
+    def create(
+        cls,
+        grid: Grid,
+        *,
+        time_step: float,
+        batch_size: int = 100,
+        n_cascades: int = 3,
+        seed: int | None = None,
+        reference_wavelength: float = 500e-9,
+        module: Any | None = None,
+    ) -> FatmossAtmosphereModel:
+        """Construct FATMOSS' ``PhaseScreensGenerator`` on a Fiatlux grid.
+
+        The upstream generator currently supports square isotropic samplings.
+        ``module`` is an injection point used by tests and alternate checkouts.
+        """
+        if grid.nx != grid.ny or grid.dx != grid.dy:
+            raise ValueError("FATMOSS requires a square grid with dx == dy.")
+        if not math.isfinite(time_step) or time_step <= 0:
+            raise ValueError("time_step must be positive and finite seconds.")
+        if not isinstance(batch_size, int) or isinstance(batch_size, bool) or batch_size < 1:
+            raise ValueError("batch_size must be a positive integer.")
+        if not isinstance(n_cascades, int) or isinstance(n_cascades, bool) or n_cascades < 1:
+            raise ValueError("n_cascades must be a positive integer.")
+
+        if module is None:
+            try:
+                module = importlib.import_module("phase_generator")
+            except ImportError as error:
+                raise FatmossUnavailableError(
+                    "FATMOSS is optional and is not importable. Clone "
+                    "https://github.com/EjjeSynho/FATMOSS and add its source "
+                    "directory to PYTHONPATH before invoking this feature."
+                ) from error
+        factory = getattr(module, "PhaseScreensGenerator", None)
+        if not callable(factory):
+            raise FatmossUnavailableError(
+                "The imported FATMOSS module has no PhaseScreensGenerator."
+            )
+        backend = factory(
+            D=grid.nx * grid.dx,
+            dx=grid.dx,
+            dt=time_step,
+            batch_size=batch_size,
+            n_cascades=n_cascades,
+            seed=seed,
+            double_precision=grid.dtype == torch.float64,
+        )
+        return cls(
+            grid,
+            backend,
+            reference_wavelength=reference_wavelength,
+            screen_unit="nm",
+            source_axes="xy",
+        )
+
+    def sample_opd(
+        self,
+        *,
+        generator: torch.Generator | None = None,
+        remove_piston: bool = True,
+    ) -> torch.Tensor:
+        """Return the next FATMOSS screen as OPD in metres on the Fiatlux grid."""
+        if generator is not None:
+            raise ValueError(
+                "FATMOSS owns its random state; seed it when constructing the backend."
+            )
+        raw = self.backend.GetScreenByTimestep(self.timestep)
+        self.timestep += 1
+        if isinstance(raw, torch.Tensor):
+            screen = raw
+        elif hasattr(raw, "__dlpack__"):
+            screen = torch.from_dlpack(raw)
+        else:
+            screen = torch.as_tensor(raw)
+        if self.source_axes == "xy":
+            screen = screen.transpose(-2, -1)
+        if tuple(screen.shape) != self.grid.shape:
+            raise ValueError(
+                f"FATMOSS screen has converted shape {tuple(screen.shape)}; "
+                f"expected Fiatlux grid shape {self.grid.shape}."
+            )
+        screen = screen.to(device=self.grid.device, dtype=self.dtype)
+        if self.screen_unit == "nm":
+            screen = screen * 1e-9
+        if remove_piston:
+            screen = screen - screen.mean()
+        return screen
+
+    def seek(self, timestep: int) -> None:
+        """Select the absolute FATMOSS timestep returned by the next call."""
+        if not isinstance(timestep, int) or isinstance(timestep, bool) or timestep < 0:
+            raise ValueError("timestep must be a non-negative integer.")
+        self.timestep = timestep

--- a/tests/test_fatmoss.py
+++ b/tests/test_fatmoss.py
@@ -1,0 +1,87 @@
+import types
+
+import numpy as np
+import pytest
+import torch
+
+from fiatlux import FatmossAtmosphereModel, FatmossUnavailableError, Grid
+
+
+class FakeBackend:
+    def __init__(self):
+        self.requested = []
+
+    def GetScreenByTimestep(self, timestep):
+        self.requested.append(timestep)
+        return np.arange(6, dtype=np.float32).reshape(3, 2) + 10 * timestep
+
+
+def test_adapter_converts_axes_nanometres_dtype_and_piston():
+    grid = Grid(3, 2, 0.1, 0.2, dtype=torch.float64)
+    backend = FakeBackend()
+    model = FatmossAtmosphereModel(grid, backend)
+
+    first = model.sample_opd(remove_piston=False)
+    second = model.sample_opd(remove_piston=True)
+
+    expected = torch.arange(6, dtype=torch.float64).reshape(3, 2).T * 1e-9
+    torch.testing.assert_close(first, expected)
+    assert second.mean().abs() < 1e-20
+    assert backend.requested == [0, 1]
+    assert first.shape == grid.shape
+    assert first.dtype == grid.dtype
+
+
+def test_seek_selects_an_absolute_backend_timestep():
+    backend = FakeBackend()
+    model = FatmossAtmosphereModel(Grid(3, 2, 0.1, 0.2), backend)
+    model.seek(17)
+    model.sample_opd()
+    assert backend.requested == [17]
+
+
+def test_factory_translates_grid_time_and_precision():
+    captured = {}
+
+    def factory(**kwargs):
+        captured.update(kwargs)
+        return FakeBackend()
+
+    module = types.SimpleNamespace(PhaseScreensGenerator=factory)
+    grid = Grid(8, 8, 0.25, 0.25, dtype=torch.float64)
+    model = FatmossAtmosphereModel.create(
+        grid,
+        time_step=0.002,
+        batch_size=16,
+        n_cascades=2,
+        seed=42,
+        module=module,
+    )
+
+    assert model.backend is not None
+    assert captured == {
+        "D": 2.0,
+        "dx": 0.25,
+        "dt": 0.002,
+        "batch_size": 16,
+        "n_cascades": 2,
+        "seed": 42,
+        "double_precision": True,
+    }
+
+
+def test_factory_rejects_grids_unsupported_by_upstream():
+    module = types.SimpleNamespace(PhaseScreensGenerator=lambda **kwargs: FakeBackend())
+    with pytest.raises(ValueError, match="square grid"):
+        FatmossAtmosphereModel.create(
+            Grid(8, 6, 0.25, 0.25), time_step=0.001, module=module
+        )
+
+
+def test_missing_backend_fails_only_when_factory_is_invoked(monkeypatch):
+    def unavailable(name):
+        raise ImportError(name)
+
+    monkeypatch.setattr("fiatlux.optics.fatmoss.importlib.import_module", unavailable)
+    with pytest.raises(FatmossUnavailableError, match="FATMOSS is optional"):
+        FatmossAtmosphereModel.create(Grid(8, 8, 0.25, 0.25), time_step=0.001)


### PR DESCRIPTION
## Summary

- add a narrow optional adapter around FATMOSS `PhaseScreensGenerator`
- keep core Fiatlux imports independent from FATMOSS
- translate screen axes from upstream `(x, y)` to Fiatlux `(ny, nx)`
- convert upstream nanometre OPD screens to metres
- preserve Fiatlux grid dtype and device, including DLPack-capable CuPy arrays
- expose deterministic absolute timestep selection
- provide a factory translating diameter, sampling, cadence, batches, cascades, seed and precision
- test the integration with a lightweight fake backend
- document installation and the currently supported upstream commit

## Upstream status

FATMOSS currently has no Python packaging metadata, so this PR deliberately does not add a broken optional pip extra. It targets [EjjeSynho/FATMOSS](https://github.com/EjjeSynho/FATMOSS) commit `12e608686dfc69955f722e2ee62455fcd3e32d2e`.

## Physical contract

- spatial lengths: metres
- time step: seconds
- FATMOSS input screen convention: nanometres OPD, `(x, y)`
- Fiatlux output: metres OPD, `(ny, nx)`
- no target-RMS renormalization and no PSD modification
- FATMOSS owns its seeded temporal random state

## Validation

Static checks pass locally. GitHub Actions performs the authoritative NumPy/PyTorch tests and verifies that Fiatlux imports without FATMOSS installed.

Closes #93