### PR TITLE
Add explicit FATMOSS frozen-flow sequences

### DIFF
--- a/docs/fatmoss.md
+++ b/docs/fatmoss.md
@@ -36,14 +36,51 @@ model = FatmossAtmosphereModel.create(
 )
 ```
 
-Layers are added through `model.backend` using FATMOSS' current `Layer` API.
-The dedicated frozen-flow and multilayer issues will wrap that construction in
-Fiatlux-owned physical layer configurations.
+## Frozen-flow sequences
+
+Use a Fiatlux-owned physical configuration instead of constructing FATMOSS
+layers directly:
+
+```python
+from fiatlux import FatmossAtmosphereModel, FrozenFlowLayer
+
+model = FatmossAtmosphereModel.create_frozen_flow(
+    grid,
+    [FrozenFlowLayer(
+        r0=0.15,
+        outer_scale=25.0,
+        wind_speed=10.0,
+        wind_direction=45.0,
+    )],
+    time_step=1e-3,
+    seed=42,
+)
+
+opd_now = model.current_opd()       # metres; does not advance time
+phase_now = model.current_phase()   # radians at reference_wavelength
+model.advance()
+opd_at_10_ms = model.opd_at(0.010)  # state is unchanged by the query
+cube = model.sequence_opd(100)      # (time, ny, nx), then advances 100 steps
+```
+
+`wind_speed` is in m/s and `wind_direction` is in degrees, following FATMOSS.
+The physical displacement per cadence is passed to FATMOSS without rounding,
+so fractional-pixel frozen-flow translations are preserved. A time supplied to
+`opd_at()`, `phase_at()` or `seek_time()` must lie exactly on the configured
+cadence.
+
+Optical evaluation and time advancement are deliberately separate for models
+created by `create_frozen_flow()`: repeated calls to `sample_opd()` return the
+same instant until `advance()` or `seek_time()` is called. This makes it possible
+to propagate multiple wavelengths or optical branches through one atmosphere
+state without accidentally moving the turbulence between evaluations.
 
 ## Conventions
 
 - `Grid.dx`, `Grid.dy` and generator diameter `D`: metres.
 - `time_step`: seconds.
+- `FrozenFlowLayer.r0`, `outer_scale`, `altitude`: metres.
+- `FrozenFlowLayer.wind_speed`: m/s; `wind_direction`: degrees.
 - `reference_wavelength`: metres in Fiatlux; FATMOSS currently uses 500 nm.
 - upstream screens: nanometres of OPD in `(x, y)` order.
 - `sample_opd()` output: metres of OPD in Fiatlux `(ny, nx)` order.

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -42,7 +42,11 @@ from .optics.detector import Detector
 from .optics.adc import ADCDispersionModel
 from .optics.atmosphere import AtmosphereModel, KolmogorovAtmosphereModel, NCPAModel
 from .optics.pupil_validation import PupilComparison, compare_pupil_masks
-from .optics.fatmoss import FatmossAtmosphereModel, FatmossUnavailableError
+from .optics.fatmoss import (
+    FatmossAtmosphereModel,
+    FatmossUnavailableError,
+    FrozenFlowLayer,
+)
 
 # =========================
 # Optical elements
@@ -122,6 +126,7 @@ __all__ = [
     "compare_pupil_masks",
     "FatmossAtmosphereModel",
     "FatmossUnavailableError",
+    "FrozenFlowLayer",
     # Elements
     "OpticalElement",
     "DeformableMirror",

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -9,7 +9,11 @@ from .propagator import (
     Propagator,
 )
 from .pupil_validation import PupilComparison, compare_pupil_masks
-from .fatmoss import FatmossAtmosphereModel, FatmossUnavailableError
+from .fatmoss import (
+    FatmossAtmosphereModel,
+    FatmossUnavailableError,
+    FrozenFlowLayer,
+)
 
 __all__ = [
     "ADCDispersionModel",
@@ -26,4 +30,5 @@ __all__ = [
     "compare_pupil_masks",
     "FatmossAtmosphereModel",
     "FatmossUnavailableError",
+    "FrozenFlowLayer",
 ]

--- a/fiatlux/optics/fatmoss.py
+++ b/fiatlux/optics/fatmoss.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import math
+from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 import torch
@@ -19,6 +20,34 @@ class FatmossBackend(Protocol):
     """Narrow subset of FATMOSS consumed by Fiatlux."""
 
     def GetScreenByTimestep(self, timestep: int) -> Any: ...
+
+    def AddLayer(self, layer: Any) -> None: ...
+
+
+@dataclass(frozen=True)
+class FrozenFlowLayer:
+    """Physical configuration of one FATMOSS frozen-flow layer."""
+
+    r0: float
+    outer_scale: float
+    wind_speed: float
+    wind_direction: float
+    weight: float = 1.0
+    altitude: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("r0", "outer_scale"):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be positive and finite metres.")
+        if not math.isfinite(self.wind_speed) or self.wind_speed < 0:
+            raise ValueError("wind_speed must be finite and non-negative m/s.")
+        if not math.isfinite(self.wind_direction):
+            raise ValueError("wind_direction must be finite degrees.")
+        if not math.isfinite(self.weight) or self.weight <= 0:
+            raise ValueError("weight must be positive and finite.")
+        if not math.isfinite(self.altitude) or self.altitude < 0:
+            raise ValueError("altitude must be finite and non-negative metres.")
 
 
 class FatmossAtmosphereModel:
@@ -39,6 +68,8 @@ class FatmossAtmosphereModel:
         screen_unit: Literal["nm", "m"] = "nm",
         source_axes: Literal["xy", "yx"] = "xy",
         initial_timestep: int = 0,
+        advance_after_sample: bool = True,
+        time_step: float | None = None,
     ) -> None:
         if not math.isfinite(reference_wavelength) or reference_wavelength <= 0:
             raise ValueError("reference_wavelength must be positive and finite.")
@@ -52,6 +83,10 @@ class FatmossAtmosphereModel:
             or initial_timestep < 0
         ):
             raise ValueError("initial_timestep must be a non-negative integer.")
+        if time_step is not None and (
+            not math.isfinite(time_step) or time_step <= 0
+        ):
+            raise ValueError("time_step must be positive and finite seconds.")
         if not callable(getattr(backend, "GetScreenByTimestep", None)):
             raise TypeError("FATMOSS backend must define GetScreenByTimestep(timestep).")
 
@@ -61,6 +96,8 @@ class FatmossAtmosphereModel:
         self.screen_unit = screen_unit
         self.source_axes = source_axes
         self.timestep = initial_timestep
+        self.advance_after_sample = bool(advance_after_sample)
+        self.time_step = None if time_step is None else float(time_step)
         self.dtype = grid.dtype
         # ``Atmosphere`` forwards this value to ``sample_opd``. FATMOSS owns
         # its seeded RNG, so no independent torch.Generator is advertised.
@@ -121,7 +158,77 @@ class FatmossAtmosphereModel:
             reference_wavelength=reference_wavelength,
             screen_unit="nm",
             source_axes="xy",
+            time_step=time_step,
         )
+
+    @classmethod
+    def create_frozen_flow(
+        cls,
+        grid: Grid,
+        layers: list[FrozenFlowLayer] | tuple[FrozenFlowLayer, ...],
+        *,
+        time_step: float,
+        batch_size: int = 100,
+        n_cascades: int = 3,
+        seed: int | None = None,
+        reference_wavelength: float = 500e-9,
+        phase_generator_module: Any | None = None,
+        layer_module: Any | None = None,
+    ) -> FatmossAtmosphereModel:
+        """Create a non-boiling FATMOSS sequence from physical layer configs."""
+        if not layers:
+            raise ValueError("At least one frozen-flow layer is required.")
+        if not all(isinstance(layer, FrozenFlowLayer) for layer in layers):
+            raise TypeError("layers must contain FrozenFlowLayer instances.")
+        model = cls.create(
+            grid,
+            time_step=time_step,
+            batch_size=batch_size,
+            n_cascades=n_cascades,
+            seed=seed,
+            reference_wavelength=reference_wavelength,
+            module=phase_generator_module,
+        )
+        if layer_module is None:
+            try:
+                layer_module = importlib.import_module("atmospheric_layer")
+            except ImportError as error:
+                raise FatmossUnavailableError(
+                    "FATMOSS atmospheric_layer.py is not importable."
+                ) from error
+        layer_factory = getattr(layer_module, "Layer", None)
+        von_karman = getattr(layer_module, "vonKarmanPSD", None)
+        simple_boiling = getattr(layer_module, "SimpleBoiling", None)
+        if not all(callable(item) for item in (layer_factory, von_karman, simple_boiling)):
+            raise FatmossUnavailableError(
+                "FATMOSS atmospheric_layer must expose Layer, vonKarmanPSD and SimpleBoiling."
+            )
+
+        wavelength_nm = reference_wavelength * 1e9
+        for config in layers:
+            spatial_psd = lambda frequency, c=config: von_karman(
+                frequency, c.r0, c.outer_scale, wavelength_nm
+            )
+            temporal_psd = lambda frequency: simple_boiling(frequency, grid.dx)
+            backend_layer = layer_factory(
+                config.weight,
+                config.altitude,
+                config.wind_speed,
+                config.wind_direction,
+                0.0,
+                spatial_psd,
+                temporal_psd,
+            )
+            model.backend.AddLayer(backend_layer)
+        model.advance_after_sample = False
+        return model
+
+    @property
+    def current_time(self) -> float:
+        """Physical time in seconds at the currently selected screen."""
+        if self.time_step is None:
+            raise RuntimeError("This model has no configured physical time_step.")
+        return self.timestep * self.time_step
 
     def sample_opd(
         self,
@@ -129,13 +236,19 @@ class FatmossAtmosphereModel:
         generator: torch.Generator | None = None,
         remove_piston: bool = True,
     ) -> torch.Tensor:
-        """Return the next FATMOSS screen as OPD in metres on the Fiatlux grid."""
+        """Return OPD in metres, advancing only for legacy sequential models."""
         if generator is not None:
             raise ValueError(
                 "FATMOSS owns its random state; seed it when constructing the backend."
             )
+        screen = self.current_opd(remove_piston=remove_piston)
+        if self.advance_after_sample:
+            self.advance()
+        return screen
+
+    def current_opd(self, *, remove_piston: bool = True) -> torch.Tensor:
+        """Return OPD at the selected timestep without advancing time."""
         raw = self.backend.GetScreenByTimestep(self.timestep)
-        self.timestep += 1
         if isinstance(raw, torch.Tensor):
             screen = raw
         elif hasattr(raw, "__dlpack__"):
@@ -155,6 +268,62 @@ class FatmossAtmosphereModel:
         if remove_piston:
             screen = screen - screen.mean()
         return screen
+
+    def current_phase(self, *, remove_piston: bool = True) -> torch.Tensor:
+        """Return phase in radians at ``reference_wavelength`` without advancing."""
+        return self.current_opd(remove_piston=remove_piston) * (
+            2.0 * math.pi / self.reference_wavelength
+        )
+
+    def advance(self, steps: int = 1) -> None:
+        """Advance the temporal state independently from optical propagation."""
+        if not isinstance(steps, int) or isinstance(steps, bool) or steps < 0:
+            raise ValueError("steps must be a non-negative integer.")
+        self.timestep += steps
+
+    def sequence_opd(
+        self, number: int, *, advance: bool = True, remove_piston: bool = True
+    ) -> torch.Tensor:
+        """Return ``number`` consecutive OPD screens shaped ``(time, ny, nx)``."""
+        if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+            raise ValueError("number must be a positive integer.")
+        start = self.timestep
+        screens = []
+        try:
+            for offset in range(number):
+                self.timestep = start + offset
+                screens.append(self.current_opd(remove_piston=remove_piston))
+        finally:
+            self.timestep = start + number if advance else start
+        return torch.stack(screens)
+
+    def opd_at(self, time: float, *, remove_piston: bool = True) -> torch.Tensor:
+        """Return OPD at an exact cadence time without changing temporal state."""
+        start = self.timestep
+        try:
+            self.seek_time(time)
+            return self.current_opd(remove_piston=remove_piston)
+        finally:
+            self.timestep = start
+
+    def phase_at(self, time: float, *, remove_piston: bool = True) -> torch.Tensor:
+        """Return phase in radians at an exact cadence time without advancing."""
+        return self.opd_at(time, remove_piston=remove_piston) * (
+            2.0 * math.pi / self.reference_wavelength
+        )
+
+    def seek_time(self, time: float) -> None:
+        """Select a physical time that lies on the configured FATMOSS cadence."""
+        if self.time_step is None:
+            raise RuntimeError("This model has no configured physical time_step.")
+        if not math.isfinite(time) or time < 0:
+            raise ValueError("time must be finite and non-negative seconds.")
+        timestep = round(time / self.time_step)
+        if not math.isclose(
+            time, timestep * self.time_step, rel_tol=1e-12, abs_tol=1e-15
+        ):
+            raise ValueError("time must be an integer multiple of time_step.")
+        self.seek(timestep)
 
     def seek(self, timestep: int) -> None:
         """Select the absolute FATMOSS timestep returned by the next call."""

--- a/tests/test_fatmoss.py
+++ b/tests/test_fatmoss.py
@@ -4,7 +4,12 @@ import numpy as np
 import pytest
 import torch
 
-from fiatlux import FatmossAtmosphereModel, FatmossUnavailableError, Grid
+from fiatlux import (
+    FatmossAtmosphereModel,
+    FatmossUnavailableError,
+    FrozenFlowLayer,
+    Grid,
+)
 
 
 class FakeBackend:
@@ -14,6 +19,49 @@ class FakeBackend:
     def GetScreenByTimestep(self, timestep):
         self.requested.append(timestep)
         return np.arange(6, dtype=np.float32).reshape(3, 2) + 10 * timestep
+
+
+class TranslatingBackend:
+    def __init__(self, **kwargs):
+        self.settings = kwargs
+        self.layers = []
+        self.size = round(kwargs["D"] / kwargs["dx"])
+
+    def AddLayer(self, layer):
+        self.layers.append(layer)
+
+    def GetScreenByTimestep(self, timestep):
+        layer = self.layers[0]
+        pixels = layer.wind_speed * self.settings["dt"] * timestep / self.settings["dx"]
+        x = np.arange(self.size, dtype=float)[:, None]
+        return np.cos(2 * np.pi * (x - pixels) / self.size) * np.ones(
+            (1, self.size)
+        )
+
+
+def fake_layer_module():
+    def layer(*args):
+        names = (
+            "weight",
+            "altitude",
+            "wind_speed",
+            "wind_direction",
+            "boiling_factor",
+            "PSD_spatial_func",
+            "PSD_temporal_func",
+        )
+        return types.SimpleNamespace(**dict(zip(names, args)))
+
+    return types.SimpleNamespace(
+        Layer=layer,
+        vonKarmanPSD=lambda frequency, r0, outer_scale, wavelength: (
+            frequency,
+            r0,
+            outer_scale,
+            wavelength,
+        ),
+        SimpleBoiling=lambda frequency, sampling: (frequency, sampling),
+    )
 
 
 def test_adapter_converts_axes_nanometres_dtype_and_piston():
@@ -85,3 +133,103 @@ def test_missing_backend_fails_only_when_factory_is_invoked(monkeypatch):
     monkeypatch.setattr("fiatlux.optics.fatmoss.importlib.import_module", unavailable)
     with pytest.raises(FatmossUnavailableError, match="FATMOSS is optional"):
         FatmossAtmosphereModel.create(Grid(8, 8, 0.25, 0.25), time_step=0.001)
+
+
+def test_frozen_flow_factory_maps_physical_layer_without_rounding_motion():
+    grid = Grid(8, 8, 0.2, 0.2, dtype=torch.float64)
+    backend_holder = {}
+
+    def factory(**kwargs):
+        backend_holder["backend"] = TranslatingBackend(**kwargs)
+        return backend_holder["backend"]
+
+    model = FatmossAtmosphereModel.create_frozen_flow(
+        grid,
+        [
+            FrozenFlowLayer(
+                r0=0.15,
+                outer_scale=25.0,
+                wind_speed=1.0,
+                wind_direction=37.0,
+                weight=0.8,
+                altitude=1200.0,
+            )
+        ],
+        time_step=0.1,
+        seed=23,
+        reference_wavelength=600e-9,
+        phase_generator_module=types.SimpleNamespace(PhaseScreensGenerator=factory),
+        layer_module=fake_layer_module(),
+    )
+
+    backend = backend_holder["backend"]
+    layer = backend.layers[0]
+    assert backend.settings["seed"] == 23
+    assert (layer.weight, layer.altitude) == (0.8, 1200.0)
+    assert (layer.wind_speed, layer.wind_direction) == (1.0, 37.0)
+    assert layer.boiling_factor == 0.0
+    assert layer.PSD_spatial_func("f") == ("f", 0.15, 25.0, 600.0)
+    assert layer.PSD_temporal_func("f") == ("f", 0.2)
+
+    # v * dt / dx = 0.5 pixel: the cadence is passed through continuously.
+    x = np.arange(8, dtype=float)[:, None]
+    expected_nm = np.cos(2 * np.pi * (x - 0.5) / 8) * np.ones((1, 8))
+    expected = torch.as_tensor(expected_nm.T * 1e-9, dtype=torch.float64)
+    torch.testing.assert_close(model.opd_at(0.1, remove_piston=False), expected)
+
+
+def test_frozen_flow_time_is_independent_from_optical_sampling():
+    grid = Grid(8, 8, 0.2, 0.2)
+    backend = TranslatingBackend(
+        D=1.6,
+        dx=0.2,
+        dt=0.05,
+        batch_size=4,
+        n_cascades=1,
+        seed=4,
+        double_precision=False,
+    )
+    backend.AddLayer(types.SimpleNamespace(wind_speed=0.5))
+    model = FatmossAtmosphereModel(
+        grid, backend, advance_after_sample=False, time_step=0.05
+    )
+
+    first = model.sample_opd(remove_piston=False)
+    torch.testing.assert_close(model.sample_opd(remove_piston=False), first)
+    assert model.current_time == 0.0
+
+    model.advance()
+    assert model.current_time == pytest.approx(0.05)
+    assert not torch.equal(model.current_opd(remove_piston=False), first)
+    with pytest.raises(ValueError, match="integer multiple"):
+        model.seek_time(0.075)
+
+
+def test_sequence_and_phase_queries_have_explicit_state_semantics():
+    grid = Grid(8, 8, 0.2, 0.2)
+    backend = TranslatingBackend(
+        D=1.6,
+        dx=0.2,
+        dt=0.05,
+        batch_size=4,
+        n_cascades=1,
+        seed=4,
+        double_precision=False,
+    )
+    backend.AddLayer(types.SimpleNamespace(wind_speed=0.5))
+    model = FatmossAtmosphereModel(
+        grid, backend, advance_after_sample=False, time_step=0.05
+    )
+
+    screens = model.sequence_opd(3, advance=False, remove_piston=False)
+    assert screens.shape == (3, *grid.shape)
+    assert model.timestep == 0
+    phase = model.phase_at(0.1, remove_piston=False)
+    torch.testing.assert_close(
+        phase,
+        screens[2] * (2 * np.pi / model.reference_wavelength),
+    )
+    assert model.timestep == 0
+
+    model.sequence_opd(3, advance=True)
+    assert model.timestep == 3


### PR DESCRIPTION
## Summary

- add `FrozenFlowLayer` with explicit physical units
- construct non-boiling FATMOSS layers from Fiatlux configuration
- preserve fractional-pixel motion by passing continuous wind speed and cadence to FATMOSS
- expose `current_opd()`, `current_phase()`, `opd_at(t)`, `phase_at(t)`, `advance()`, `seek_time()` and finite OPD sequences
- keep optical sampling separate from temporal advancement for frozen-flow models
- retain the legacy sequential behavior of the lower-level adapter
- validate layer mapping, a 0.5-pixel displacement, cadence rules, phase conversion and state semantics with an injected backend
- document the frozen-flow workflow and unit contract

## Temporal contract

A frozen-flow model stays at the selected instant while it is sampled. Time changes only through `advance()`, `seek_time()`, or an advancing `sequence_opd()`. Queries at physical time `t` do not mutate the selected instant, and `t` must lie on the configured cadence.

## Validation

`compileall`, `py_compile`, and `git diff --check` pass locally. The local environment does not contain NumPy/PyTorch test dependencies, so GitHub Actions is authoritative for the pytest suite.

Closes #92