### PR TITLE
Support FATMOSS multilayer profiles and long runs

### DIFF
--- a/docs/fatmoss.md
+++ b/docs/fatmoss.md
@@ -75,6 +75,41 @@ same instant until `advance()` or `seek_time()` is called. This makes it possibl
 to propagate multiple wavelengths or optical branches through one atmosphere
 state without accidentally moving the turbulence between evaluations.
 
+## Multilayer profiles and long runs
+
+Pass several `FrozenFlowLayer` objects to combine their altitude, wind vector
+and relative amplitude. FATMOSS applies `weight` linearly to each OPD screen;
+it is therefore an OPD-amplitude weight, not a fraction of OPD variance or
+`Cn2`. Set `normalize_weights=True` to normalize arbitrary positive relative
+weights so that they sum to one before they are sent to FATMOSS:
+
+```python
+layers = [
+    FrozenFlowLayer(0.15, 25.0, 5.0, 0.0, weight=2, altitude=0),
+    FrozenFlowLayer(0.15, 25.0, 12.0, 90.0, weight=8, altitude=9000),
+]
+model = FatmossAtmosphereModel.create_frozen_flow(
+    grid, layers, time_step=1e-3, seed=42, normalize_weights=True
+)
+```
+
+For a long or unbounded simulation, iterate instead of allocating a temporal
+cube:
+
+```python
+for opd in model.iter_opd(number=1_000_000):
+    consume(opd)
+
+# Or omit number for an unbounded iterator.
+for opd in model.iter_opd():
+    consume(opd)
+```
+
+Each value yielded by `iter_opd()` advances the selected timestep once. Fiatlux
+does not retain the sequence; FATMOSS retains only its configured internal
+batch. `reset()` resets the backend to its original seed, regenerates its layers
+and returns the model to `t=0`.
+
 ## Conventions
 
 - `Grid.dx`, `Grid.dy` and generator diameter `D`: metres.

--- a/fiatlux/optics/fatmoss.py
+++ b/fiatlux/optics/fatmoss.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import math
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
@@ -22,6 +23,8 @@ class FatmossBackend(Protocol):
     def GetScreenByTimestep(self, timestep: int) -> Any: ...
 
     def AddLayer(self, layer: Any) -> None: ...
+
+    def reset(self, regenerate_layers: bool = True) -> None: ...
 
 
 @dataclass(frozen=True)
@@ -165,13 +168,14 @@ class FatmossAtmosphereModel:
     def create_frozen_flow(
         cls,
         grid: Grid,
-        layers: list[FrozenFlowLayer] | tuple[FrozenFlowLayer, ...],
+        layers: Sequence[FrozenFlowLayer],
         *,
         time_step: float,
         batch_size: int = 100,
         n_cascades: int = 3,
         seed: int | None = None,
         reference_wavelength: float = 500e-9,
+        normalize_weights: bool = False,
         phase_generator_module: Any | None = None,
         layer_module: Any | None = None,
     ) -> FatmossAtmosphereModel:
@@ -180,6 +184,8 @@ class FatmossAtmosphereModel:
             raise ValueError("At least one frozen-flow layer is required.")
         if not all(isinstance(layer, FrozenFlowLayer) for layer in layers):
             raise TypeError("layers must contain FrozenFlowLayer instances.")
+        if not isinstance(normalize_weights, bool):
+            raise TypeError("normalize_weights must be a boolean.")
         model = cls.create(
             grid,
             time_step=time_step,
@@ -204,6 +210,8 @@ class FatmossAtmosphereModel:
                 "FATMOSS atmospheric_layer must expose Layer, vonKarmanPSD and SimpleBoiling."
             )
 
+        total_weight = sum(config.weight for config in layers)
+        weight_scale = 1.0 / total_weight if normalize_weights else 1.0
         wavelength_nm = reference_wavelength * 1e9
         for config in layers:
             spatial_psd = lambda frequency, c=config: von_karman(
@@ -211,7 +219,7 @@ class FatmossAtmosphereModel:
             )
             temporal_psd = lambda frequency: simple_boiling(frequency, grid.dx)
             backend_layer = layer_factory(
-                config.weight,
+                config.weight * weight_scale,
                 config.altitude,
                 config.wind_speed,
                 config.wind_direction,
@@ -280,6 +288,32 @@ class FatmossAtmosphereModel:
         if not isinstance(steps, int) or isinstance(steps, bool) or steps < 0:
             raise ValueError("steps must be a non-negative integer.")
         self.timestep += steps
+
+    def reset(self) -> None:
+        """Reset FATMOSS' seeded state and select the first physical instant."""
+        backend_reset = getattr(self.backend, "reset", None)
+        if not callable(backend_reset):
+            raise NotImplementedError("This FATMOSS backend does not support reset().")
+        backend_reset(regenerate_layers=True)
+        self.timestep = 0
+
+    def iter_opd(
+        self,
+        number: int | None = None,
+        *,
+        remove_piston: bool = True,
+    ) -> Iterator[torch.Tensor]:
+        """Yield screens lazily while retaining only FATMOSS' current batch."""
+        if number is not None and (
+            not isinstance(number, int) or isinstance(number, bool) or number < 0
+        ):
+            raise ValueError("number must be a non-negative integer or None.")
+        produced = 0
+        while number is None or produced < number:
+            screen = self.current_opd(remove_piston=remove_piston)
+            self.advance()
+            produced += 1
+            yield screen
 
     def sequence_opd(
         self, number: int, *, advance: bool = True, remove_piston: bool = True

--- a/tests/test_fatmoss.py
+++ b/tests/test_fatmoss.py
@@ -1,4 +1,5 @@
 import types
+from itertools import islice
 
 import numpy as np
 import pytest
@@ -25,18 +26,32 @@ class TranslatingBackend:
     def __init__(self, **kwargs):
         self.settings = kwargs
         self.layers = []
+        self.requested = []
+        self.reset_count = 0
         self.size = round(kwargs["D"] / kwargs["dx"])
 
     def AddLayer(self, layer):
         self.layers.append(layer)
 
     def GetScreenByTimestep(self, timestep):
+        self.requested.append(timestep)
         layer = self.layers[0]
         pixels = layer.wind_speed * self.settings["dt"] * timestep / self.settings["dx"]
         x = np.arange(self.size, dtype=float)[:, None]
         return np.cos(2 * np.pi * (x - pixels) / self.size) * np.ones(
             (1, self.size)
         )
+
+    def reset(self, regenerate_layers=True):
+        assert regenerate_layers is True
+        self.reset_count += 1
+
+
+class WeightedBackend(TranslatingBackend):
+    def GetScreenByTimestep(self, timestep):
+        self.requested.append(timestep)
+        integrated_nm = sum(layer.weight * layer.wind_speed for layer in self.layers)
+        return np.full((self.size, self.size), integrated_nm + timestep)
 
 
 def fake_layer_module():
@@ -233,3 +248,72 @@ def test_sequence_and_phase_queries_have_explicit_state_semantics():
 
     model.sequence_opd(3, advance=True)
     assert model.timestep == 3
+
+
+def test_multilayer_relative_weights_are_normalized_with_fatmoss_semantics():
+    grid = Grid(8, 8, 0.2, 0.2)
+    backend_holder = {}
+
+    def factory(**kwargs):
+        backend_holder["backend"] = WeightedBackend(**kwargs)
+        return backend_holder["backend"]
+
+    model = FatmossAtmosphereModel.create_frozen_flow(
+        grid,
+        [
+            FrozenFlowLayer(0.15, 25.0, 5.0, 0.0, weight=2.0, altitude=0.0),
+            FrozenFlowLayer(0.15, 25.0, 12.0, 90.0, weight=8.0, altitude=9000.0),
+        ],
+        time_step=0.001,
+        normalize_weights=True,
+        phase_generator_module=types.SimpleNamespace(PhaseScreensGenerator=factory),
+        layer_module=fake_layer_module(),
+    )
+
+    weights = [layer.weight for layer in model.backend.layers]
+    assert weights == pytest.approx([0.2, 0.8])
+    assert sum(weights) == pytest.approx(1.0)
+    assert [layer.altitude for layer in model.backend.layers] == [0.0, 9000.0]
+    assert [layer.wind_speed for layer in model.backend.layers] == [5.0, 12.0]
+    assert [layer.wind_direction for layer in model.backend.layers] == [0.0, 90.0]
+    expected_integrated_opd = (0.2 * 5.0 + 0.8 * 12.0) * 1e-9
+    assert model.current_opd(remove_piston=False).mean().item() == pytest.approx(
+        expected_integrated_opd
+    )
+
+
+def test_reset_is_deterministic_and_lazy_iteration_does_not_build_a_cube():
+    grid = Grid(8, 8, 0.2, 0.2)
+    backend = TranslatingBackend(
+        D=1.6,
+        dx=0.2,
+        dt=0.05,
+        batch_size=2,
+        n_cascades=1,
+        seed=4,
+        double_precision=False,
+    )
+    backend.AddLayer(types.SimpleNamespace(wind_speed=0.5))
+    model = FatmossAtmosphereModel(
+        grid, backend, advance_after_sample=False, time_step=0.05
+    )
+
+    reference = model.current_opd(remove_piston=False)
+    model.advance(37)
+    assert not torch.equal(model.current_opd(remove_piston=False), reference)
+    model.reset()
+    torch.testing.assert_close(model.current_opd(remove_piston=False), reference)
+    assert model.timestep == 0
+    assert backend.reset_count == 1
+
+    backend.requested.clear()
+    iterator = model.iter_opd(number=1_000_000, remove_piston=False)
+    first_three = list(islice(iterator, 3))
+    assert len(first_three) == 3
+    assert all(screen.dtype == grid.dtype for screen in first_three)
+    assert all(screen.device == grid.device for screen in first_three)
+    assert backend.requested == [0, 1, 2]
+    assert model.timestep == 3
+    next(iterator)
+    assert model.timestep == 4
+    assert backend.requested == [0, 1, 2, 3]


### PR DESCRIPTION
## Summary

- accept general layer sequences with altitude, wind speed, direction and relative weight
- optionally normalize positive relative weights before passing them to FATMOSS
- document that upstream weights are linear OPD-amplitude coefficients, not variance or `Cn2` fractions
- expose deterministic `reset()` through FATMOSS' seeded backend reset
- add finite or unbounded lazy `iter_opd()` generation
- keep long-run memory bounded to the current screen plus FATMOSS' configured internal batch
- preserve Fiatlux grid dtype and device for every yielded screen
- test normalized integrated layer contribution, physical profile mapping, deterministic reset and lazy million-frame iteration

## Validation

`compileall` and `git diff --check` pass locally. NumPy/PyTorch are not installed in the local runtime, so GitHub Actions is authoritative for pytest.

Closes #94