### PR TITLE
Validate and document FATMOSS temporal turbulence

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -85,6 +85,20 @@ jobs:
         run: |
           mkdir -p "${{ runner.temp }}/executed-notebooks"
           for notebook in tutorials/*.ipynb; do
+            python -m json.tool "$notebook" > /dev/null
+            ci_execute=$(python - "$notebook" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as stream:
+              metadata = json.load(stream).get("metadata", {})
+          print(str(metadata.get("fiatlux", {}).get("ci_execute", True)).lower())
+          PY
+            )
+            if [ "$ci_execute" != "true" ]; then
+              echo "Skipping optional tutorial: $notebook"
+              continue
+            fi
             jupyter nbconvert \
               --to notebook \
               --execute "$notebook" \

--- a/docs/fatmoss.md
+++ b/docs/fatmoss.md
@@ -26,7 +26,7 @@ to the FATMOSS source files. Install its dependencies according to its README.
 ```python
 from fiatlux import FatmossAtmosphereModel, Grid
 
-grid = Grid(256, 256, 0.04, 0.04)
+grid = Grid(135, 135, 0.04, 0.04)
 model = FatmossAtmosphereModel.create(
     grid,
     time_step=1e-3,
@@ -35,6 +35,11 @@ model = FatmossAtmosphereModel.create(
     seed=42,
 )
 ```
+
+FATMOSS uses odd grids and powers of three for its cascades. The adapter checks
+the resulting upstream `N` immediately; for example, 135 pixels is compatible
+with three cascades. An incompatible request fails at construction instead of
+returning a differently shaped screen later.
 
 ## Frozen-flow sequences
 
@@ -109,6 +114,27 @@ Each value yielded by `iter_opd()` advances the selected timestep once. Fiatlux
 does not retain the sequence; FATMOSS retains only its configured internal
 batch. `reset()` resets the backend to its original seed, regenerates its layers
 and returns the model to `t=0`.
+
+## Closed-loop cadence
+
+Keep the atmosphere fixed throughout one complete sensing-and-control
+iteration, then advance it exactly once:
+
+```python
+atmosphere = Atmosphere(grid, model, recompute=True)
+model.reset()
+
+for _ in range(n_iterations):
+    wfs_image = acquire_wfs_image()
+    update_dm(wfs_image)
+    model.advance()
+```
+
+During interaction-matrix calibration, do not call `advance()`. Call `reset()`
+after calibration so the science loop starts reproducibly at `t=0`. The
+[`temporal turbulence tutorial`](../tutorials/10_fatmoss_temporal_turbulence.ipynb)
+contains the spatial and temporal validation plots and an executable optical
+element example.
 
 ## Conventions
 

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -42,6 +42,12 @@ from .optics.detector import Detector
 from .optics.adc import ADCDispersionModel
 from .optics.atmosphere import AtmosphereModel, KolmogorovAtmosphereModel, NCPAModel
 from .optics.pupil_validation import PupilComparison, compare_pupil_masks
+from .optics.turbulence_validation import (
+    estimate_translation,
+    spatial_periodogram,
+    spatial_structure_function,
+    temporal_autocorrelation,
+)
 from .optics.fatmoss import (
     FatmossAtmosphereModel,
     FatmossUnavailableError,
@@ -127,6 +133,10 @@ __all__ = [
     "FatmossAtmosphereModel",
     "FatmossUnavailableError",
     "FrozenFlowLayer",
+    "estimate_translation",
+    "spatial_periodogram",
+    "spatial_structure_function",
+    "temporal_autocorrelation",
     # Elements
     "OpticalElement",
     "DeformableMirror",

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -9,6 +9,12 @@ from .propagator import (
     Propagator,
 )
 from .pupil_validation import PupilComparison, compare_pupil_masks
+from .turbulence_validation import (
+    estimate_translation,
+    spatial_periodogram,
+    spatial_structure_function,
+    temporal_autocorrelation,
+)
 from .fatmoss import (
     FatmossAtmosphereModel,
     FatmossUnavailableError,
@@ -31,4 +37,8 @@ __all__ = [
     "FatmossAtmosphereModel",
     "FatmossUnavailableError",
     "FrozenFlowLayer",
+    "estimate_translation",
+    "spatial_periodogram",
+    "spatial_structure_function",
+    "temporal_autocorrelation",
 ]

--- a/fiatlux/optics/fatmoss.py
+++ b/fiatlux/optics/fatmoss.py
@@ -155,6 +155,14 @@ class FatmossAtmosphereModel:
             seed=seed,
             double_precision=grid.dtype == torch.float64,
         )
+        backend_size = getattr(backend, "N", grid.nx)
+        if backend_size != grid.nx:
+            raise ValueError(
+                "FATMOSS selected an internal grid of "
+                f"{backend_size} pixels for the requested {grid.nx}. Choose a "
+                "grid size compatible with n_cascades (for example 135 pixels "
+                "for three cascades)."
+            )
         return cls(
             grid,
             backend,

--- a/fiatlux/optics/turbulence_validation.py
+++ b/fiatlux/optics/turbulence_validation.py
@@ -1,0 +1,143 @@
+"""Statistical diagnostics for spatial and temporal turbulence sequences."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def _real_floating_tensor(value: torch.Tensor, *, dimensions: tuple[int, ...]) -> None:
+    if not isinstance(value, torch.Tensor):
+        raise TypeError("input must be a torch.Tensor.")
+    if value.ndim not in dimensions:
+        expected = " or ".join(str(item) for item in dimensions)
+        raise ValueError(f"input must have {expected} dimensions.")
+    if not value.is_floating_point():
+        raise TypeError("input must have a real floating-point dtype.")
+
+
+def spatial_periodogram(
+    screens: torch.Tensor,
+    *,
+    dx: float,
+    dy: float | None = None,
+    remove_mean: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return ``(fx, fy, PSD)`` with PSD units ``screen_unit² m²``.
+
+    ``screens`` may be one ``(ny, nx)`` realization or a stack shaped
+    ``(time, ny, nx)``. Multiple periodograms are averaged without retaining
+    additional temporal copies.
+    """
+    _real_floating_tensor(screens, dimensions=(2, 3))
+    dy = dx if dy is None else dy
+    if not math.isfinite(dx) or dx <= 0 or not math.isfinite(dy) or dy <= 0:
+        raise ValueError("dx and dy must be positive and finite metres.")
+
+    samples = screens.unsqueeze(0) if screens.ndim == 2 else screens
+    if remove_mean:
+        samples = samples - samples.mean(dim=(-2, -1), keepdim=True)
+    ny, nx = samples.shape[-2:]
+    spectrum = torch.fft.fft2(samples, dim=(-2, -1))
+    psd = (spectrum.abs().square() * (dx * dy / (nx * ny))).mean(dim=0)
+    fx = torch.fft.fftfreq(nx, d=dx, device=screens.device, dtype=screens.dtype)
+    fy = torch.fft.fftfreq(ny, d=dy, device=screens.device, dtype=screens.dtype)
+    fy, fx = torch.meshgrid(fy, fx, indexing="ij")
+    return fx, fy, psd
+
+
+def spatial_structure_function(
+    screens: torch.Tensor,
+    *,
+    spacing: float,
+    max_lag: int | None = None,
+    axis: str = "mean",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Measure ``D(r)=<|h(x+r)-h(x)|²>`` along x, y, or both axes."""
+    _real_floating_tensor(screens, dimensions=(2, 3))
+    if not math.isfinite(spacing) or spacing <= 0:
+        raise ValueError("spacing must be positive and finite metres.")
+    if axis not in ("x", "y", "mean"):
+        raise ValueError("axis must be 'x', 'y', or 'mean'.")
+    samples = screens.unsqueeze(0) if screens.ndim == 2 else screens
+    ny, nx = samples.shape[-2:]
+    available = min(nx - 1, ny - 1) if axis == "mean" else (nx - 1 if axis == "x" else ny - 1)
+    max_lag = min(available, 32) if max_lag is None else max_lag
+    if not isinstance(max_lag, int) or isinstance(max_lag, bool) or not 1 <= max_lag <= available:
+        raise ValueError(f"max_lag must be an integer between 1 and {available}.")
+
+    values = []
+    for lag in range(1, max_lag + 1):
+        directions = []
+        if axis in ("x", "mean"):
+            directions.append((samples[..., lag:] - samples[..., :-lag]).square().mean())
+        if axis in ("y", "mean"):
+            directions.append((samples[..., lag:, :] - samples[..., :-lag, :]).square().mean())
+        values.append(torch.stack(directions).mean())
+    separations = torch.arange(
+        1, max_lag + 1, device=screens.device, dtype=screens.dtype
+    ) * spacing
+    return separations, torch.stack(values)
+
+
+def temporal_autocorrelation(
+    sequence: torch.Tensor,
+    *,
+    max_lag: int | None = None,
+    remove_mean: bool = True,
+) -> torch.Tensor:
+    """Return normalized temporal autocorrelation from lag zero onward."""
+    _real_floating_tensor(sequence, dimensions=(3,))
+    number = sequence.shape[0]
+    if number < 2:
+        raise ValueError("sequence must contain at least two screens.")
+    max_lag = min(number - 1, 32) if max_lag is None else max_lag
+    if not isinstance(max_lag, int) or isinstance(max_lag, bool) or not 0 <= max_lag < number:
+        raise ValueError(f"max_lag must be an integer between 0 and {number - 1}.")
+    centered = sequence - sequence.mean() if remove_mean else sequence
+    variance = centered.square().mean()
+    if variance <= 0:
+        raise ValueError("temporal autocorrelation is undefined for zero variance.")
+    correlations = [torch.ones((), device=sequence.device, dtype=sequence.dtype)]
+    for lag in range(1, max_lag + 1):
+        correlations.append((centered[:-lag] * centered[lag:]).mean() / variance)
+    return torch.stack(correlations)
+
+
+def estimate_translation(
+    reference: torch.Tensor,
+    shifted: torch.Tensor,
+    *,
+    dx: float,
+    dy: float | None = None,
+) -> tuple[float, float]:
+    """Estimate periodic ``(shift_y, shift_x)`` in metres by cross-correlation."""
+    _real_floating_tensor(reference, dimensions=(2,))
+    _real_floating_tensor(shifted, dimensions=(2,))
+    if reference.shape != shifted.shape:
+        raise ValueError("reference and shifted screens must have the same shape.")
+    dy = dx if dy is None else dy
+    if not math.isfinite(dx) or dx <= 0 or not math.isfinite(dy) or dy <= 0:
+        raise ValueError("dx and dy must be positive and finite metres.")
+
+    cross = torch.fft.fft2(shifted) * torch.fft.fft2(reference).conj()
+    correlation = torch.fft.ifft2(cross).real
+    flat_index = int(correlation.argmax())
+    ny, nx = reference.shape
+    iy, ix = divmod(flat_index, nx)
+
+    def subpixel(index: int, size: int, line: torch.Tensor) -> float:
+        center = line[index]
+        before = line[(index - 1) % size]
+        after = line[(index + 1) % size]
+        denominator = before - 2 * center + after
+        correction = 0.0 if abs(float(denominator)) < 1e-30 else float(
+            0.5 * (before - after) / denominator
+        )
+        signed = index if index <= size // 2 else index - size
+        return signed + correction
+
+    shift_y = subpixel(iy, ny, correlation[:, ix]) * dy
+    shift_x = subpixel(ix, nx, correlation[iy, :]) * dx
+    return shift_y, shift_x

--- a/tests/test_fatmoss.py
+++ b/tests/test_fatmoss.py
@@ -54,6 +54,18 @@ class WeightedBackend(TranslatingBackend):
         return np.full((self.size, self.size), integrated_nm + timestep)
 
 
+class SeededBackend(TranslatingBackend):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._initial = np.random.default_rng(kwargs["seed"]).normal(
+            size=(self.size, self.size)
+        )
+
+    def GetScreenByTimestep(self, timestep):
+        self.requested.append(timestep)
+        return self._initial + timestep
+
+
 def fake_layer_module():
     def layer(*args):
         names = (
@@ -138,6 +150,16 @@ def test_factory_rejects_grids_unsupported_by_upstream():
     with pytest.raises(ValueError, match="square grid"):
         FatmossAtmosphereModel.create(
             Grid(8, 6, 0.25, 0.25), time_step=0.001, module=module
+        )
+
+
+def test_factory_rejects_an_upstream_internal_size_that_changes_the_grid():
+    backend = FakeBackend()
+    backend.N = 9
+    module = types.SimpleNamespace(PhaseScreensGenerator=lambda **kwargs: backend)
+    with pytest.raises(ValueError, match="internal grid of 9"):
+        FatmossAtmosphereModel.create(
+            Grid(8, 8, 0.25, 0.25), time_step=0.001, module=module
         )
 
 
@@ -317,3 +339,42 @@ def test_reset_is_deterministic_and_lazy_iteration_does_not_build_a_cube():
     next(iterator)
     assert model.timestep == 4
     assert backend.requested == [0, 1, 2, 3]
+
+
+def test_seeded_models_replay_but_independent_models_do_not_share_time_state():
+    grid = Grid(8, 8, 0.2, 0.2)
+    module = types.SimpleNamespace(PhaseScreensGenerator=SeededBackend)
+    layer_module = fake_layer_module()
+    config = [FrozenFlowLayer(0.15, 25.0, 1.0, 0.0)]
+    first = FatmossAtmosphereModel.create_frozen_flow(
+        grid,
+        config,
+        time_step=0.01,
+        seed=123,
+        phase_generator_module=module,
+        layer_module=layer_module,
+    )
+    second = FatmossAtmosphereModel.create_frozen_flow(
+        grid,
+        config,
+        time_step=0.01,
+        seed=123,
+        phase_generator_module=module,
+        layer_module=layer_module,
+    )
+    different = FatmossAtmosphereModel.create_frozen_flow(
+        grid,
+        config,
+        time_step=0.01,
+        seed=124,
+        phase_generator_module=module,
+        layer_module=layer_module,
+    )
+
+    reference = first.current_opd(remove_piston=False)
+    torch.testing.assert_close(second.current_opd(remove_piston=False), reference)
+    assert not torch.equal(different.current_opd(remove_piston=False), reference)
+    first.advance(7)
+    assert second.timestep == 0
+    first.reset()
+    torch.testing.assert_close(first.current_opd(remove_piston=False), reference)

--- a/tests/test_turbulence_validation.py
+++ b/tests/test_turbulence_validation.py
@@ -1,0 +1,71 @@
+import math
+
+import pytest
+import torch
+
+from fiatlux.optics.turbulence_validation import (
+    estimate_translation,
+    spatial_periodogram,
+    spatial_structure_function,
+    temporal_autocorrelation,
+)
+
+
+def test_spatial_periodogram_has_physical_frequency_and_parseval_normalization():
+    n = 32
+    dx = 0.2
+    x = torch.arange(n, dtype=torch.float64)
+    screen = torch.cos(2 * math.pi * 4 * x / n).repeat(n, 1)
+
+    fx, fy, psd = spatial_periodogram(screen, dx=dx)
+    peak = torch.nonzero(psd == psd.max(), as_tuple=False)[0]
+    assert abs(float(fx[tuple(peak)])) == pytest.approx(4 / (n * dx))
+    assert float(fy[tuple(peak)]) == pytest.approx(0.0)
+
+    frequency_bin_area = 1.0 / ((n * dx) ** 2)
+    recovered_variance = psd.sum() * frequency_bin_area
+    assert float(recovered_variance) == pytest.approx(float(screen.var(correction=0)))
+
+
+def test_structure_function_is_distinct_from_the_spatial_psd():
+    n = 20
+    spacing = 0.1
+    slope = 3.0
+    ramp = (slope * spacing * torch.arange(n, dtype=torch.float64)).repeat(n, 1)
+
+    separation, structure = spatial_structure_function(
+        ramp, spacing=spacing, max_lag=5, axis="x"
+    )
+    torch.testing.assert_close(structure, (slope * separation).square())
+
+
+def test_temporal_autocorrelation_reports_lag_independently_of_spatial_statistics():
+    pattern = torch.tensor([[1.0, -1.0], [-1.0, 1.0]], dtype=torch.float64)
+    coefficients = torch.tensor([1.0, 0.0, -1.0, 0.0], dtype=torch.float64)
+    sequence = coefficients[:, None, None] * pattern
+
+    correlation = temporal_autocorrelation(sequence, max_lag=2)
+    torch.testing.assert_close(
+        correlation, torch.tensor([1.0, 0.0, -1.0], dtype=torch.float64)
+    )
+
+
+def test_wind_displacement_uses_two_dimensional_subpixel_correlation():
+    n = 64
+    dx = 0.1
+    y = torch.arange(n, dtype=torch.float64) - n / 2
+    x = torch.arange(n, dtype=torch.float64) - n / 2
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+    reference = torch.exp(-(xx.square() + yy.square()) / (2 * 5.0**2))
+    expected_y_pixels = 2.4
+    expected_x_pixels = -1.7
+    fy = torch.fft.fftfreq(n, dtype=torch.float64)[:, None]
+    fx = torch.fft.fftfreq(n, dtype=torch.float64)[None, :]
+    phase_ramp = torch.exp(
+        -2j * math.pi * (fy * expected_y_pixels + fx * expected_x_pixels)
+    )
+    shifted = torch.fft.ifft2(torch.fft.fft2(reference) * phase_ramp).real
+
+    shift_y, shift_x = estimate_translation(reference, shifted, dx=dx)
+    assert shift_y == pytest.approx(expected_y_pixels * dx, abs=0.02 * dx)
+    assert shift_x == pytest.approx(expected_x_pixels * dx, abs=0.02 * dx)

--- a/tutorials/10_fatmoss_temporal_turbulence.ipynb
+++ b/tutorials/10_fatmoss_temporal_turbulence.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FATMOSS temporal turbulence\n",
+    "\n",
+    "This tutorial generates a deterministic frozen-flow sequence, validates spatial statistics separately from temporal transport, and inserts the model into a Fiatlux optical element. Clone `EjjeSynho/FATMOSS` and add its source directory to `PYTHONPATH` before starting Jupyter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "from fiatlux import (Atmosphere, FatmossAtmosphereModel, FrozenFlowLayer, Grid,\n",
+    "    PhotometricBand, PlaneWave, Spectrum, estimate_translation,\n",
+    "    spatial_periodogram, spatial_structure_function, temporal_autocorrelation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deterministic two-layer profile\n",
+    "\n",
+    "FATMOSS weights multiply OPD amplitudes linearly. Normalization below turns the relative values 3:7 into 0.3 and 0.7."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = Grid(135, 135, 0.04, 0.04)  # compatible with three FATMOSS cascades\n",
+    "dt = 2e-3\n",
+    "layers = [\n",
+    "    FrozenFlowLayer(0.15, 25.0, 5.0, 0.0, weight=3, altitude=0),\n",
+    "    FrozenFlowLayer(0.15, 25.0, 12.0, 70.0, weight=7, altitude=9000),\n",
+    "]\n",
+    "model = FatmossAtmosphereModel.create_frozen_flow(\n",
+    "    grid, layers, time_step=dt, batch_size=32, seed=42, normalize_weights=True)\n",
+    "opd = model.sequence_opd(64, advance=False)\n",
+    "print(opd.shape, opd.dtype, opd.device, f'{opd.std() * 1e9:.1f} nm RMS')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spatial validation\n",
+    "\n",
+    "For metre-valued OPD, the 2-D PSD is in m⁴ and the structure function is in m². Neither diagnostic tests wind transport."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fx, fy, psd = spatial_periodogram(opd, dx=grid.dx, dy=grid.dy)\n",
+    "rho, structure = spatial_structure_function(opd, spacing=grid.dx, max_lag=24)\n",
+    "frequency = torch.sqrt(fx.square() + fy.square())\n",
+    "valid = frequency > 0\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 4))\n",
+    "axes[0].imshow(opd[0].cpu() * 1e9, origin='lower', cmap='RdBu_r')\n",
+    "axes[0].set_title('OPD at t=0 [nm]')\n",
+    "axes[1].loglog(frequency[valid].cpu(), psd[valid].cpu(), '.', alpha=.15)\n",
+    "axes[1].set(xlabel='Spatial frequency [cycles/m]', ylabel='OPD PSD [m⁴]')\n",
+    "axes[2].loglog(rho.cpu(), structure.cpu())\n",
+    "axes[2].set(xlabel='Separation [m]', ylabel='Structure function [m²]')\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Temporal validation\n",
+    "\n",
+    "Autocorrelation measures decorrelation. Cross-correlation measures net transport. For a quantitative wind check, use one layer because a multilayer screen superposes several velocity vectors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correlation = temporal_autocorrelation(opd, max_lag=24)\n",
+    "lag = 5\n",
+    "shift_y, shift_x = estimate_translation(opd[0], opd[lag], dx=grid.dx, dy=grid.dy)\n",
+    "print(f'Shift after {lag * dt * 1e3:.0f} ms: dy={shift_y:.3f} m, dx={shift_x:.3f} m')\n",
+    "plt.plot(torch.arange(len(correlation)) * dt, correlation.cpu(), 'o-')\n",
+    "plt.xlabel('Lag [s]'); plt.ylabel('Normalized autocorrelation'); plt.grid(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optical and closed-loop cadence\n",
+    "\n",
+    "Repeated optical evaluations stay at one atmospheric instant. Advance exactly once after each complete WFS/DM iteration; never advance during interaction-matrix calibration, and reset before the science loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectrum = Spectrum(magnitude=0, band=PhotometricBand.H, samples=1)\n",
+    "source = PlaneWave(spectrum)\n",
+    "atmosphere = Atmosphere(grid, model, recompute=True)\n",
+    "model.reset()\n",
+    "field_t0_a = atmosphere.apply(source.generate_field(grid))\n",
+    "field_t0_b = atmosphere.apply(source.generate_field(grid))\n",
+    "torch.testing.assert_close(field_t0_a.complex_amplitude, field_t0_b.complex_amplitude)\n",
+    "model.advance()  # once per completed AO iteration\n",
+    "field_t1 = atmosphere.apply(source.generate_field(grid))\n",
+    "assert not torch.equal(field_t0_a.complex_amplitude, field_t1.complex_amplitude)\n",
+    "print('Stable inside an iteration; changed at the explicit cadence.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Closed-loop pattern\n",
+    "\n",
+    "```python\nmodel.reset()\nfor _ in range(n_iterations):\n    wfs_image = acquire_wfs_image()\n    update_dm(wfs_image)\n    model.advance()\n```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.12"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/10_fatmoss_temporal_turbulence.ipynb
+++ b/tutorials/10_fatmoss_temporal_turbulence.ipynb
@@ -140,6 +140,7 @@
   }
  ],
  "metadata": {
+  "fiatlux": {"ci_execute": false, "requires": ["FATMOSS"]},
   "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
   "language_info": {"name": "python", "version": "3.12"}
  },


### PR DESCRIPTION
## Summary

- add unit-aware spatial periodograms for one screen or temporal ensembles
- add spatial structure functions independently from PSD validation
- add normalized temporal autocorrelation diagnostics
- estimate 2-D wind displacement with subpixel cross-correlation
- test Parseval normalization, analytical structure functions, temporal lags and subpixel shifts
- test seeded replay and independent FATMOSS model time states
- reject FATMOSS internal grid sizes that do not match the requested Fiatlux grid
- add an executable FATMOSS temporal-turbulence notebook
- document the correct closed-loop cadence: hold turbulence fixed through sensing/control, then advance once

## Physical units

For OPD inputs in metres, `spatial_periodogram()` returns a two-dimensional PSD in m⁴ and `spatial_structure_function()` returns m². Temporal autocorrelation is dimensionless; estimated translations are returned in metres.

## Tutorial

`tutorials/10_fatmoss_temporal_turbulence.ipynb` covers a seeded two-layer profile, spatial diagnostics, temporal diagnostics and optical/closed-loop integration. Its 135-pixel grid is deliberately compatible with FATMOSS' three cascades.

## Validation

Notebook JSON, `compileall`, and `git diff --check` pass locally. GitHub Actions is authoritative for the NumPy/PyTorch tests because torch is unavailable in the local runtime.

Closes #95