### PR TITLE
Implement Shack-Hartmann lenslet-array propagation

### DIFF
--- a/docs/shack_hartmann.md
+++ b/docs/shack_hartmann.md
@@ -1,0 +1,65 @@
+# Shack-Hartmann optical model
+
+`ShackHartmannLensletArray` separates optical spot formation from centroid and
+slope extraction. It consumes a Fiatlux `Field` and returns a
+`ShackHartmannImage`; measurement algorithms are deliberately handled by the
+next layer of the sensor API.
+
+```python
+from fiatlux import Grid, ShackHartmannLensletArray
+
+grid = Grid(240, 240, 0.01, 0.01)
+lenslets = ShackHartmannLensletArray(
+    grid,
+    pitch=0.20,
+    focal_length=5e-3,
+    n_lenslets_x=12,
+    n_lenslets_y=12,
+)
+spots = lenslets.propagate(pupil_field)
+detector_flux = spots.mosaic()  # photons / s / detector pixel
+```
+
+## Tensor and coordinate conventions
+
+The complex focal field has shape
+`(n_wavelengths, n_lenslets_y, n_lenslets_x, spot_ny, spot_nx)`. Lenslet
+indices increase in the same y/x order as Fiatlux images. `registration_x` and
+`registration_y` shift the centered array in metres and currently must be
+integer multiples of the corresponding pupil-grid spacing.
+
+The hard subaperture windows contain `pitch / dx` by `pitch / dy` samples.
+These ratios must be integers. A Boolean `valid_subapertures` array can disable
+known invalid lenslets; automatic partial-illumination decisions belong to the
+dedicated illumination/noise layer.
+
+## Propagation and sampling
+
+For a thin lens of focal length `f`, its quadratic phase followed by Fresnel
+propagation over `f` reduces to a Fraunhofer transform of the windowed
+subaperture, up to the output quadratic phase. This is the batched transform
+implemented by `propagate()`. `lenslet_phase(wavelengths)` exposes the actual
+local thin-lens phase
+
+\[
+\phi_\mathrm{lens}(x,y;\lambda) =
+-\frac{\pi}{\lambda f}(x^2+y^2).
+\]
+
+Natural detector sampling depends on wavelength:
+
+\[
+\Delta u_\lambda = \frac{\lambda f}{N_x\Delta x},\qquad
+\Delta v_\lambda = \frac{\lambda f}{N_y\Delta y}.
+\]
+
+It is stored per channel in `pixel_scale_x` and `pixel_scale_y`. Consequently,
+spectral intensity densities are not blindly added on a common physical grid.
+`pixel_flux` first integrates each channel over its own pixel area, and
+`mosaic()` then returns photon rate per detector pixel. The FFT normalization
+obeys Parseval, so total output photon rate equals the rate inside enabled
+subapertures without empirical renormalization.
+
+All lenslets and wavelength channels are transformed in batches. Dtype, device
+and autograd are preserved. Fiatlux `Field` currently has no additional
+arbitrary leading batch dimension.

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -48,6 +48,7 @@ from .optics.turbulence_validation import (
     spatial_structure_function,
     temporal_autocorrelation,
 )
+from .optics.shack_hartmann import ShackHartmannImage, ShackHartmannLensletArray
 from .optics.fatmoss import (
     FatmossAtmosphereModel,
     FatmossUnavailableError,
@@ -137,6 +138,8 @@ __all__ = [
     "spatial_periodogram",
     "spatial_structure_function",
     "temporal_autocorrelation",
+    "ShackHartmannImage",
+    "ShackHartmannLensletArray",
     # Elements
     "OpticalElement",
     "DeformableMirror",

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -15,6 +15,7 @@ from .turbulence_validation import (
     spatial_structure_function,
     temporal_autocorrelation,
 )
+from .shack_hartmann import ShackHartmannImage, ShackHartmannLensletArray
 from .fatmoss import (
     FatmossAtmosphereModel,
     FatmossUnavailableError,
@@ -41,4 +42,6 @@ __all__ = [
     "spatial_periodogram",
     "spatial_structure_function",
     "temporal_autocorrelation",
+    "ShackHartmannImage",
+    "ShackHartmannLensletArray",
 ]

--- a/fiatlux/optics/shack_hartmann.py
+++ b/fiatlux/optics/shack_hartmann.py
@@ -1,0 +1,216 @@
+"""Optical formation of Shack-Hartmann lenslet-array spots."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+from fiatlux.core.field import Field
+from fiatlux.core.grid import Grid
+from fiatlux.optics.elements.base import validate_field_grid
+
+
+def _positive_finite(value: float, name: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise TypeError(f"{name} must be a real number in metres.")
+    value = float(value)
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be positive and finite.")
+    return value
+
+
+@dataclass(frozen=True)
+class ShackHartmannImage:
+    """Spectral lenslet focal fields and their wavelength-dependent sampling.
+
+    ``complex_amplitude`` is shaped
+    ``(n_wavelengths, n_lenslets_y, n_lenslets_x, spot_ny, spot_nx)`` and has
+    units ``sqrt(photons / s / m²)``. Each wavelength has its own natural
+    detector sampling, stored in ``pixel_scale_x`` and ``pixel_scale_y``.
+    """
+
+    complex_amplitude: torch.Tensor
+    wavelengths: torch.Tensor
+    pixel_scale_x: torch.Tensor
+    pixel_scale_y: torch.Tensor
+    valid_subapertures: torch.Tensor
+
+    @property
+    def intensity(self) -> torch.Tensor:
+        """Spectral photon-rate density in photons / s / m²."""
+        return self.complex_amplitude.abs().square()
+
+    @property
+    def pixel_flux(self) -> torch.Tensor:
+        """Spectral photon rate in every detector pixel."""
+        pixel_area = self.pixel_scale_x * self.pixel_scale_y
+        return self.intensity * pixel_area[:, None, None, None, None]
+
+    def mosaic(self, wavelength_index: int | None = None) -> torch.Tensor:
+        """Tile spots into a detector image expressed as photons / s / pixel."""
+        flux = self.pixel_flux
+        if wavelength_index is None:
+            flux = flux.sum(dim=0)
+        else:
+            flux = flux[wavelength_index]
+        nly, nlx, spot_ny, spot_nx = flux.shape
+        return flux.permute(0, 2, 1, 3).reshape(nly * spot_ny, nlx * spot_nx)
+
+
+class ShackHartmannLensletArray:
+    """Form independent focal spots behind a registered square lenslet array.
+
+    The lenslet pitch must contain an integer number of input samples. The
+    covered array is centered on the pupil grid, then shifted by the registered
+    integer-pixel offsets. Each lenslet is propagated to its own focal plane by
+    the Fraunhofer transform equivalent to a thin-lens phase followed by a
+    distance equal to ``focal_length``.
+    """
+
+    def __init__(
+        self,
+        grid: Grid,
+        *,
+        pitch: float,
+        focal_length: float,
+        n_lenslets_x: int | None = None,
+        n_lenslets_y: int | None = None,
+        registration_x: float = 0.0,
+        registration_y: float = 0.0,
+        valid_subapertures: torch.Tensor | None = None,
+    ) -> None:
+        if not isinstance(grid, Grid):
+            raise TypeError("grid must be a fiatlux Grid.")
+        self.grid = grid
+        self.pitch = _positive_finite(pitch, "pitch")
+        self.focal_length = _positive_finite(focal_length, "focal_length")
+        self.samples_x = self._integer_samples(self.pitch, grid.dx, "pitch / dx")
+        self.samples_y = self._integer_samples(self.pitch, grid.dy, "pitch / dy")
+        maximum_x = grid.nx // self.samples_x
+        maximum_y = grid.ny // self.samples_y
+        self.n_lenslets_x = self._lenslet_count(n_lenslets_x, maximum_x, "x")
+        self.n_lenslets_y = self._lenslet_count(n_lenslets_y, maximum_y, "y")
+        offset_x = self._integer_offset(registration_x, grid.dx, "registration_x")
+        offset_y = self._integer_offset(registration_y, grid.dy, "registration_y")
+        covered_x = self.n_lenslets_x * self.samples_x
+        covered_y = self.n_lenslets_y * self.samples_y
+        self.start_x = (grid.nx - covered_x) // 2 + offset_x
+        self.start_y = (grid.ny - covered_y) // 2 + offset_y
+        if self.start_x < 0 or self.start_x + covered_x > grid.nx:
+            raise ValueError("registered lenslet array exceeds the grid along x.")
+        if self.start_y < 0 or self.start_y + covered_y > grid.ny:
+            raise ValueError("registered lenslet array exceeds the grid along y.")
+
+        expected = (self.n_lenslets_y, self.n_lenslets_x)
+        if valid_subapertures is None:
+            valid_subapertures = torch.ones(expected, dtype=torch.bool, device=grid.device)
+        elif not isinstance(valid_subapertures, torch.Tensor):
+            raise TypeError("valid_subapertures must be a torch.Tensor.")
+        elif tuple(valid_subapertures.shape) != expected:
+            raise ValueError(
+                f"valid_subapertures must have shape {expected}, got "
+                f"{tuple(valid_subapertures.shape)}."
+            )
+        self.valid_subapertures = valid_subapertures.to(
+            device=grid.device, dtype=torch.bool
+        )
+
+    @staticmethod
+    def _integer_samples(length: float, spacing: float, name: str) -> int:
+        samples = round(length / spacing)
+        if samples < 1 or not math.isclose(
+            length, samples * spacing, rel_tol=1e-9, abs_tol=1e-15
+        ):
+            raise ValueError(f"{name} must be a positive integer.")
+        return samples
+
+    @staticmethod
+    def _integer_offset(offset: float, spacing: float, name: str) -> int:
+        if not isinstance(offset, (int, float)) or isinstance(offset, bool):
+            raise TypeError(f"{name} must be a real number in metres.")
+        pixels = round(offset / spacing)
+        if not math.isfinite(offset) or not math.isclose(
+            offset, pixels * spacing, rel_tol=1e-9, abs_tol=1e-15
+        ):
+            raise ValueError(f"{name} must be an integer multiple of grid spacing.")
+        return pixels
+
+    @staticmethod
+    def _lenslet_count(value: int | None, maximum: int, axis: str) -> int:
+        value = maximum if value is None else value
+        if not isinstance(value, int) or isinstance(value, bool) or not 1 <= value <= maximum:
+            raise ValueError(
+                f"n_lenslets_{axis} must be an integer between 1 and {maximum}."
+            )
+        return value
+
+    def lenslet_phase(self, wavelengths: torch.Tensor) -> torch.Tensor:
+        """Return the local thin-lens phase in radians for every wavelength."""
+        if not isinstance(wavelengths, torch.Tensor) or wavelengths.ndim != 1:
+            raise TypeError("wavelengths must be a one-dimensional torch.Tensor.")
+        wavelengths = wavelengths.to(
+            device=self.grid.device, dtype=self.grid.dtype
+        )
+        if torch.any(~torch.isfinite(wavelengths)) or torch.any(wavelengths <= 0):
+            raise ValueError("wavelengths must be positive and finite metres.")
+        x = (
+            torch.arange(self.samples_x, device=self.grid.device, dtype=self.grid.dtype)
+            - (self.samples_x - 1) / 2
+        ) * self.grid.dx
+        y = (
+            torch.arange(self.samples_y, device=self.grid.device, dtype=self.grid.dtype)
+            - (self.samples_y - 1) / 2
+        ) * self.grid.dy
+        radius_squared = y[:, None].square() + x[None, :].square()
+        return -torch.pi * radius_squared[None] / (
+            wavelengths[:, None, None] * self.focal_length
+        )
+
+    def propagate(self, field: Field) -> ShackHartmannImage:
+        """Window the pupil and form all spectral lenslet spots in one batch."""
+        validate_field_grid(field, self.grid, self.__class__.__name__)
+        stop_x = self.start_x + self.n_lenslets_x * self.samples_x
+        stop_y = self.start_y + self.n_lenslets_y * self.samples_y
+        cropped = field.complex_amplitude[
+            :, self.start_y:stop_y, self.start_x:stop_x
+        ]
+        n_wavelengths = cropped.shape[0]
+        subapertures = cropped.reshape(
+            n_wavelengths,
+            self.n_lenslets_y,
+            self.samples_y,
+            self.n_lenslets_x,
+            self.samples_x,
+        ).permute(0, 1, 3, 2, 4)
+        spectrum = torch.fft.fftshift(
+            torch.fft.fft2(
+                torch.fft.ifftshift(subapertures, dim=(-2, -1)),
+                dim=(-2, -1),
+            ),
+            dim=(-2, -1),
+        )
+        wavelengths = field.spectrum.wavelengths.to(
+            device=self.grid.device, dtype=self.grid.dtype
+        )
+        scale = self.grid.dx * self.grid.dy / (
+            wavelengths * self.focal_length
+        )
+        amplitude = spectrum * scale[:, None, None, None, None]
+        amplitude = amplitude * self.valid_subapertures[
+            None, :, :, None, None
+        ]
+        pixel_scale_x = wavelengths * self.focal_length / (
+            self.samples_x * self.grid.dx
+        )
+        pixel_scale_y = wavelengths * self.focal_length / (
+            self.samples_y * self.grid.dy
+        )
+        return ShackHartmannImage(
+            complex_amplitude=amplitude,
+            wavelengths=wavelengths,
+            pixel_scale_x=pixel_scale_x,
+            pixel_scale_y=pixel_scale_y,
+            valid_subapertures=self.valid_subapertures,
+        )

--- a/tests/test_shack_hartmann.py
+++ b/tests/test_shack_hartmann.py
@@ -1,0 +1,135 @@
+import math
+
+import pytest
+import torch
+
+from fiatlux import (
+    Field,
+    Grid,
+    PlaneWave,
+    ShackHartmannLensletArray,
+    Spectrum,
+)
+from fiatlux.core.spectrum import Band
+
+
+def monochromatic_field(grid, wavelength=500e-9):
+    spectrum = Spectrum(
+        magnitude=0,
+        band=Band(wavelength, 0.0, 368.0),
+        samples=1,
+        dtype=grid.dtype,
+        device=grid.device,
+    )
+    return PlaneWave(spectrum).generate_field(grid)
+
+
+def test_flat_wavefront_forms_regular_spots_and_conserves_flux():
+    grid = Grid(16, 16, 0.1, 0.1, dtype=torch.float64)
+    field = monochromatic_field(grid)
+    sensor = ShackHartmannLensletArray(
+        grid, pitch=0.4, focal_length=2.0
+    )
+
+    spots = sensor.propagate(field)
+    assert spots.complex_amplitude.shape == (1, 4, 4, 4, 4)
+    peak = spots.pixel_flux[0].reshape(16, -1).argmax(dim=1)
+    assert torch.equal(peak, torch.full((16,), 2 * 4 + 2))
+    input_flux = field.intensity().sum() * grid.dx * grid.dy
+    torch.testing.assert_close(spots.pixel_flux.sum(), input_flux)
+
+    mosaic = spots.mosaic()
+    assert mosaic.shape == (16, 16)
+    assert int((mosaic > 0).sum()) == 16
+
+
+def test_known_wavefront_tilt_moves_every_spot_with_correct_sign_and_scale():
+    wavelength = 500e-9
+    grid = Grid(16, 16, 0.1, 0.1, dtype=torch.float64)
+    field = monochromatic_field(grid, wavelength)
+    sensor = ShackHartmannLensletArray(grid, pitch=0.4, focal_length=2.0)
+    angle_x = wavelength / sensor.pitch
+    x, _ = grid.meshgrid()
+    tilted = Field(
+        field.complex_amplitude
+        * torch.exp(2j * math.pi * angle_x * x[None] / wavelength),
+        grid,
+        field.spectrum,
+    )
+
+    spots = sensor.propagate(tilted)
+    peak = spots.pixel_flux[0, 0, 0].argmax()
+    peak_y, peak_x = divmod(int(peak), sensor.samples_x)
+    assert (peak_y, peak_x) == (2, 3)
+    measured_position = (peak_x - 2) * float(spots.pixel_scale_x[0])
+    assert measured_position == pytest.approx(sensor.focal_length * angle_x)
+
+
+def test_rectangular_grid_polychromatic_sampling_dtype_and_autograd():
+    grid = Grid(12, 8, 0.1, 0.2, dtype=torch.float64)
+    spectrum = Spectrum(
+        magnitude=0,
+        band=Band(600e-9, 200e-9, 368.0),
+        samples=3,
+        dtype=torch.float64,
+    )
+    source_field = PlaneWave(spectrum).generate_field(grid)
+    amplitude = source_field.complex_amplitude.detach().clone().requires_grad_(True)
+    field = Field(amplitude, grid, spectrum)
+    sensor = ShackHartmannLensletArray(grid, pitch=0.4, focal_length=3.0)
+
+    spots = sensor.propagate(field)
+    assert spots.complex_amplitude.shape == (3, 4, 3, 2, 4)
+    assert spots.complex_amplitude.dtype == torch.complex128
+    assert spots.pixel_scale_x.dtype == torch.float64
+    assert torch.all(spots.pixel_scale_x[1:] > spots.pixel_scale_x[:-1])
+    assert torch.all(spots.pixel_scale_y[1:] > spots.pixel_scale_y[:-1])
+    lens_phase = sensor.lenslet_phase(spectrum.wavelengths)
+    assert lens_phase.shape == (3, 2, 4)
+    assert torch.all(lens_phase <= 0)
+    assert lens_phase[0].abs().max() > lens_phase[-1].abs().max()
+    spots.intensity.sum().backward()
+    assert amplitude.grad is not None
+    assert torch.isfinite(amplitude.grad).all()
+
+
+def test_registration_and_valid_subapertures_are_explicit():
+    grid = Grid(10, 10, 0.1, 0.1)
+    valid = torch.tensor([[True, False], [True, True]])
+    sensor = ShackHartmannLensletArray(
+        grid,
+        pitch=0.2,
+        focal_length=1.0,
+        n_lenslets_x=2,
+        n_lenslets_y=2,
+        registration_x=0.1,
+        registration_y=-0.1,
+        valid_subapertures=valid,
+    )
+    assert (sensor.start_y, sensor.start_x) == ((2, 4))
+
+    spots = sensor.propagate(monochromatic_field(grid))
+    assert spots.pixel_flux[0, 0, 1].sum() == 0
+    assert torch.all(spots.pixel_flux[0, valid].sum(dim=(-2, -1)) > 0)
+
+
+def test_pitch_and_registration_must_align_with_input_samples():
+    grid = Grid(10, 10, 0.1, 0.1)
+    with pytest.raises(ValueError, match="pitch / dx"):
+        ShackHartmannLensletArray(grid, pitch=0.25, focal_length=1.0)
+    with pytest.raises(ValueError, match="registration_x"):
+        ShackHartmannLensletArray(
+            grid, pitch=0.2, focal_length=1.0, registration_x=0.05
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cuda_device_is_preserved():
+    grid = Grid(8, 8, 0.1, 0.1, device="cuda")
+    field = monochromatic_field(grid)
+    spots = ShackHartmannLensletArray(
+        grid, pitch=0.4, focal_length=1.0
+    ).propagate(field)
+    assert spots.complex_amplitude.device.type == "cuda"
+    assert spots.pixel_scale_x.device.type == "cuda"
+    assert spots.valid_subapertures.device.type == "cuda"


### PR DESCRIPTION
## Summary

- add a registered `ShackHartmannLensletArray` optical model
- window pupil fields into an explicit `(lenslet_y, lenslet_x)` batch
- form every lenslet spot with the thin-lens/Fraunhofer-equivalent transform
- expose the physical wavelength-dependent detector sampling
- return spectral focal fields, photon-rate densities and photon flux per detector pixel
- tile spots into a regular detector mosaic without losing the lenslet axes
- support rectangular grids, polychromatic fields, valid-subaperture masks, dtype, device and autograd
- preserve flux through the physical FFT/Parseval normalization without empirical rescaling
- document phase, registration, tensor ordering and units

## Physical contract

The focal-field tensor is `(n_wavelengths, n_lenslets_y, n_lenslets_x, spot_ny, spot_nx)`. Each spectral channel retains its natural sampling `lambda*f/(N*dx)`. `pixel_flux` is therefore the quantity combined into a detector mosaic. Centroid and slope extraction remain separate and will be implemented in #78.

## Validation

Tests cover a regular flat-wave spot grid, flux conservation, the sign and physical scale of a known tilt, rectangular/polychromatic sampling, explicit registration, disabled subapertures, dtype, autograd and CUDA when available. Static compilation and whitespace checks pass locally; GitHub Actions is authoritative for runtime tests.

Closes #79