### PR TITLE
Implement Shack-Hartmann centroid and slope measurements

### DIFF
--- a/docs/shack_hartmann.md
+++ b/docs/shack_hartmann.md
@@ -63,3 +63,30 @@ subapertures without empirical renormalization.
 All lenslets and wavelength channels are transformed in batches. Dtype, device
 and autograd are preserved. Fiatlux `Field` currently has no additional
 arbitrary leading batch dimension.
+
+## Centroids and calibrated slopes
+
+`ShackHartmannSlopeEstimator` converts a `ShackHartmannImage` into a
+`ShackHartmannMeasurement`. It supports a rectangular centroid window and a
+relative threshold (a fraction of each spectral spot peak). For polychromatic
+data, it computes centroids using each wavelength's physical detector sampling
+before combining them with photon-flux weights.
+
+```python
+from fiatlux import ShackHartmannSlopeEstimator
+
+estimator = ShackHartmannSlopeEstimator(
+    focal_length=lenslets.focal_length,
+    window_radius=2,
+    threshold=0.05,
+    reference_centroids=reference_centroids,
+)
+measurement = estimator.measure(spots)
+```
+
+`measurement.centroids[..., 0]` and `[..., 1]` are detector positions in
+metres, ordered `(x, y)`. The reference-subtracted `measurement.slopes` use the
+same ordering and are small angles in radians. `measurement.slope_vector`
+contains only valid subapertures, ordered as all x slopes in row-major lenslet
+order followed by all y slopes in the same order. Empty or explicitly disabled
+subapertures return zero and are false in `valid_subapertures`.

--- a/fiatlux/__init__.py
+++ b/fiatlux/__init__.py
@@ -48,7 +48,12 @@ from .optics.turbulence_validation import (
     spatial_structure_function,
     temporal_autocorrelation,
 )
-from .optics.shack_hartmann import ShackHartmannImage, ShackHartmannLensletArray
+from .optics.shack_hartmann import (
+    ShackHartmannImage,
+    ShackHartmannLensletArray,
+    ShackHartmannMeasurement,
+    ShackHartmannSlopeEstimator,
+)
 from .optics.fatmoss import (
     FatmossAtmosphereModel,
     FatmossUnavailableError,
@@ -140,6 +145,8 @@ __all__ = [
     "temporal_autocorrelation",
     "ShackHartmannImage",
     "ShackHartmannLensletArray",
+    "ShackHartmannMeasurement",
+    "ShackHartmannSlopeEstimator",
     # Elements
     "OpticalElement",
     "DeformableMirror",

--- a/fiatlux/optics/__init__.py
+++ b/fiatlux/optics/__init__.py
@@ -15,7 +15,12 @@ from .turbulence_validation import (
     spatial_structure_function,
     temporal_autocorrelation,
 )
-from .shack_hartmann import ShackHartmannImage, ShackHartmannLensletArray
+from .shack_hartmann import (
+    ShackHartmannImage,
+    ShackHartmannLensletArray,
+    ShackHartmannMeasurement,
+    ShackHartmannSlopeEstimator,
+)
 from .fatmoss import (
     FatmossAtmosphereModel,
     FatmossUnavailableError,
@@ -44,4 +49,6 @@ __all__ = [
     "temporal_autocorrelation",
     "ShackHartmannImage",
     "ShackHartmannLensletArray",
+    "ShackHartmannMeasurement",
+    "ShackHartmannSlopeEstimator",
 ]

--- a/fiatlux/optics/shack_hartmann.py
+++ b/fiatlux/optics/shack_hartmann.py
@@ -59,6 +59,153 @@ class ShackHartmannImage:
         return flux.permute(0, 2, 1, 3).reshape(nly * spot_ny, nlx * spot_nx)
 
 
+@dataclass(frozen=True)
+class ShackHartmannMeasurement:
+    """Calibrated Shack-Hartmann centroids and wavefront slopes.
+
+    The last axis of ``centroids`` and ``slopes`` is ordered ``(x, y)``.
+    Centroids are detector-plane positions in metres and slopes are angles in
+    radians (dimensionless in SI). Invalid subapertures contain zeros and are
+    identified by ``valid_subapertures``.
+    """
+
+    centroids: torch.Tensor
+    reference_centroids: torch.Tensor
+    slopes: torch.Tensor
+    valid_subapertures: torch.Tensor
+
+    @property
+    def slope_vector(self) -> torch.Tensor:
+        """Return valid slopes as ``[x row-major, y row-major]``."""
+        valid = self.valid_subapertures
+        return torch.cat((self.slopes[..., 0][valid], self.slopes[..., 1][valid]))
+
+
+class ShackHartmannSlopeEstimator:
+    """Extract flux-weighted centroids and calibrated slopes from lenslet spots.
+
+    ``window_radius`` is an optional half-width in detector pixels, either one
+    integer for both axes or ``(y, x)``. ``threshold`` is a fraction of each
+    spectral spot's peak pixel flux. Centroids are first evaluated in physical
+    detector coordinates for every wavelength and then combined by spectral
+    flux; this is required because the natural pixel scale changes with
+    wavelength.
+    """
+
+    def __init__(
+        self,
+        *,
+        focal_length: float,
+        window_radius: int | tuple[int, int] | None = None,
+        threshold: float = 0.0,
+        reference_centroids: torch.Tensor | None = None,
+    ) -> None:
+        self.focal_length = _positive_finite(focal_length, "focal_length")
+        self.window_radius = self._window_radius(window_radius)
+        if (
+            not isinstance(threshold, (int, float))
+            or isinstance(threshold, bool)
+            or not math.isfinite(threshold)
+            or not 0 <= threshold < 1
+        ):
+            raise ValueError("threshold must be finite and in [0, 1).")
+        self.threshold = float(threshold)
+        if reference_centroids is not None and not isinstance(
+            reference_centroids, torch.Tensor
+        ):
+            raise TypeError("reference_centroids must be a torch.Tensor.")
+        self.reference_centroids = reference_centroids
+
+    @staticmethod
+    def _window_radius(
+        value: int | tuple[int, int] | None,
+    ) -> tuple[int, int] | None:
+        if value is None:
+            return None
+        if isinstance(value, int) and not isinstance(value, bool):
+            value = (value, value)
+        if (
+            not isinstance(value, tuple)
+            or len(value) != 2
+            or any(
+                not isinstance(v, int) or isinstance(v, bool) or v < 0
+                for v in value
+            )
+        ):
+            raise ValueError("window_radius must be a non-negative integer or (y, x).")
+        return value
+
+    def measure(
+        self,
+        image: ShackHartmannImage,
+        *,
+        reference_centroids: torch.Tensor | None = None,
+    ) -> ShackHartmannMeasurement:
+        """Measure centroids and reference-subtracted wavefront slopes."""
+        if not isinstance(image, ShackHartmannImage):
+            raise TypeError("image must be a ShackHartmannImage.")
+        flux = image.pixel_flux
+        _, nly, nlx, spot_ny, spot_nx = flux.shape
+        work = flux
+
+        if self.window_radius is not None:
+            radius_y, radius_x = self.window_radius
+            iy = torch.arange(spot_ny, device=flux.device)
+            ix = torch.arange(spot_nx, device=flux.device)
+            window = (
+                (iy[:, None] - spot_ny // 2).abs() <= radius_y
+            ) & ((ix[None, :] - spot_nx // 2).abs() <= radius_x)
+            work = work * window[None, None, None]
+
+        if self.threshold:
+            peak = work.amax(dim=(-2, -1), keepdim=True)
+            work = torch.where(work >= self.threshold * peak, work, 0)
+
+        x = (
+            torch.arange(spot_nx, device=flux.device, dtype=flux.dtype)
+            - spot_nx // 2
+        ) * image.pixel_scale_x[:, None]
+        y = (
+            torch.arange(spot_ny, device=flux.device, dtype=flux.dtype)
+            - spot_ny // 2
+        ) * image.pixel_scale_y[:, None]
+        total_flux = work.sum(dim=(0, -2, -1))
+        numerator_x = (work * x[:, None, None, None, :]).sum(dim=(0, -2, -1))
+        numerator_y = (work * y[:, None, None, :, None]).sum(dim=(0, -2, -1))
+        illuminated = total_flux > 0
+        safe_flux = torch.where(illuminated, total_flux, torch.ones_like(total_flux))
+        centroids = torch.stack(
+            (numerator_x / safe_flux, numerator_y / safe_flux), dim=-1
+        )
+
+        reference = reference_centroids
+        if reference is None:
+            reference = self.reference_centroids
+        expected = (nly, nlx, 2)
+        if reference is None:
+            reference = torch.zeros(expected, device=flux.device, dtype=flux.dtype)
+        elif tuple(reference.shape) != expected:
+            raise ValueError(
+                f"reference_centroids must have shape {expected}, got "
+                f"{tuple(reference.shape)}."
+            )
+        else:
+            reference = reference.to(device=flux.device, dtype=flux.dtype)
+
+        valid = image.valid_subapertures.to(device=flux.device) & illuminated
+        slopes = (centroids - reference) / self.focal_length
+        slopes = torch.where(valid[..., None], slopes, torch.zeros_like(slopes))
+        centroids = torch.where(
+            valid[..., None], centroids, torch.zeros_like(centroids)
+        )
+        return ShackHartmannMeasurement(
+            centroids=centroids,
+            reference_centroids=reference,
+            slopes=slopes,
+            valid_subapertures=valid,
+        )
+
+
 class ShackHartmannLensletArray:
     """Form independent focal spots behind a registered square lenslet array.
 

--- a/tests/test_shack_hartmann.py
+++ b/tests/test_shack_hartmann.py
@@ -7,7 +7,9 @@ from fiatlux import (
     Field,
     Grid,
     PlaneWave,
+    ShackHartmannImage,
     ShackHartmannLensletArray,
+    ShackHartmannSlopeEstimator,
     Spectrum,
 )
 from fiatlux.core.spectrum import Band
@@ -120,6 +122,101 @@ def test_pitch_and_registration_must_align_with_input_samples():
     with pytest.raises(ValueError, match="registration_x"):
         ShackHartmannLensletArray(
             grid, pitch=0.2, focal_length=1.0, registration_x=0.05
+        )
+
+
+def test_centroids_recover_known_xy_tilt_sign_and_scale():
+    wavelength = 500e-9
+    grid = Grid(24, 16, 0.1, 0.1, dtype=torch.float64)
+    field = monochromatic_field(grid, wavelength)
+    sensor = ShackHartmannLensletArray(grid, pitch=0.4, focal_length=2.0)
+    angle_x = wavelength / sensor.pitch
+    angle_y = -wavelength / sensor.pitch
+    x, y = grid.meshgrid()
+    tilted = Field(
+        field.complex_amplitude
+        * torch.exp(2j * math.pi * (angle_x * x + angle_y * y)[None] / wavelength),
+        grid,
+        field.spectrum,
+    )
+
+    measurement = ShackHartmannSlopeEstimator(
+        focal_length=sensor.focal_length
+    ).measure(sensor.propagate(tilted))
+    expected = torch.tensor([angle_x, angle_y], dtype=grid.dtype)
+    torch.testing.assert_close(
+        measurement.slopes,
+        expected.expand_as(measurement.slopes),
+        rtol=1e-12,
+        atol=1e-15,
+    )
+    assert measurement.slope_vector.shape == (2 * 4 * 6,)
+    torch.testing.assert_close(
+        measurement.slope_vector[:24], expected[0].expand(24)
+    )
+    torch.testing.assert_close(
+        measurement.slope_vector[24:], expected[1].expand(24)
+    )
+
+
+def test_reference_centroids_are_subtracted_and_invalid_lenslets_are_omitted():
+    grid = Grid(8, 8, 0.1, 0.1, dtype=torch.float64)
+    valid = torch.tensor([[True, False], [True, True]])
+    sensor = ShackHartmannLensletArray(
+        grid, pitch=0.4, focal_length=2.0, valid_subapertures=valid
+    )
+    image = sensor.propagate(monochromatic_field(grid))
+    reference = torch.zeros((2, 2, 2), dtype=grid.dtype)
+    reference[..., 0] = float(image.pixel_scale_x[0])
+
+    measurement = ShackHartmannSlopeEstimator(
+        focal_length=2.0, reference_centroids=reference
+    ).measure(image)
+    torch.testing.assert_close(
+        measurement.slopes[..., 0][valid],
+        torch.full((3,), -float(image.pixel_scale_x[0]) / 2, dtype=grid.dtype),
+    )
+    assert torch.equal(
+        measurement.slopes[~valid], torch.zeros((1, 2), dtype=grid.dtype)
+    )
+    assert measurement.slope_vector.shape == (6,)
+
+
+def test_polychromatic_centroid_uses_each_channel_physical_sampling():
+    scales = torch.tensor([1.0e-6, 2.0e-6, 3.0e-6], dtype=torch.float64)
+    amplitude = torch.zeros((3, 1, 1, 3, 3), dtype=torch.complex128)
+    # Equal photon flux in the +1 x pixel of every channel.
+    amplitude[:, 0, 0, 1, 2] = scales.reciprocal()
+    image = ShackHartmannImage(
+        complex_amplitude=amplitude,
+        wavelengths=torch.tensor([500e-9, 600e-9, 700e-9]),
+        pixel_scale_x=scales,
+        pixel_scale_y=scales,
+        valid_subapertures=torch.ones((1, 1), dtype=torch.bool),
+    )
+
+    measurement = ShackHartmannSlopeEstimator(focal_length=2.0).measure(image)
+    torch.testing.assert_close(
+        measurement.slopes[..., 0], torch.tensor([[1.0e-6]], dtype=torch.float64)
+    )
+
+
+def test_centroid_window_threshold_and_validation():
+    grid = Grid(8, 8, 0.1, 0.1)
+    sensor = ShackHartmannLensletArray(grid, pitch=0.4, focal_length=1.0)
+    image = sensor.propagate(monochromatic_field(grid))
+    measurement = ShackHartmannSlopeEstimator(
+        focal_length=1.0, window_radius=(1, 1), threshold=0.5
+    ).measure(image)
+    assert torch.equal(measurement.centroids, torch.zeros_like(measurement.centroids))
+
+    with pytest.raises(ValueError, match="window_radius"):
+        ShackHartmannSlopeEstimator(focal_length=1.0, window_radius=-1)
+    with pytest.raises(ValueError, match="threshold"):
+        ShackHartmannSlopeEstimator(focal_length=1.0, threshold=1.0)
+    with pytest.raises(ValueError, match="reference_centroids"):
+        ShackHartmannSlopeEstimator(focal_length=1.0).measure(
+            image, reference_centroids=torch.zeros(2, 2)
         )
 
 


### PR DESCRIPTION
## Summary

- add a dedicated `ShackHartmannSlopeEstimator`, separate from optical spot formation
- provide center-of-gravity centroiding with configurable rectangular windows and relative thresholds
- measure each spectral channel in physical detector coordinates before photon-flux-weighted combination
- subtract configurable reference centroids and convert detector displacement to small-angle slopes through the lenslet focal length
- expose structured `(x, y)` maps plus the documented `[x row-major, y row-major]` valid-slope vector
- preserve dtype, device and tensor operations while zeroing and excluding invalid or empty subapertures
- document units, ordering, calibration and polychromatic behavior

## Validation

Tests cover exact x/y tip-tilt sign and scale, reference subtraction, invalid-subaperture ordering, wavelength-dependent physical sampling, centroid windows, thresholds and invalid configuration. Static compilation and whitespace checks pass locally; GitHub Actions is authoritative for the PyTorch runtime suite.

Closes #78