### PR TITLE
Validate Shack-Hartmann reconstruction and closed-loop correction

### DIFF
--- a/docs/shack_hartmann.md
+++ b/docs/shack_hartmann.md
@@ -33,6 +33,12 @@ These ratios must be integers. A Boolean `valid_subapertures` array can disable
 known invalid lenslets; automatic partial-illumination decisions belong to the
 dedicated illumination/noise layer.
 
+For calibrated subpixel centroiding, `spot_oversampling` zero-pads each
+subaperture before its focal FFT. For example, a 4×4 subaperture with
+`spot_oversampling=4` produces a 16×16 spot with four times finer physical
+sampling on each axis. The physical FFT normalization continues to conserve
+photon flux. The default is one for backward-compatible native sampling.
+
 ## Propagation and sampling
 
 For a thin lens of focal length `f`, its quadratic phase followed by Fresnel
@@ -140,3 +146,11 @@ to the full-well capacity. A subaperture is invalid if it is optically masked,
 below `minimum_electrons`, or contains a saturated pixel. The frame reports
 both `valid_subapertures` and `saturated_subapertures` explicitly. Random state
 is private to the detector and reproducible from `random_seed`.
+
+## End-to-end calibration
+
+The maintained `tutorials/11_shack_hartmann_end_to_end.ipynb` notebook uses the
+generic `InteractionMatrix` with `measurement.slope_vector`. It calibrates tip,
+tilt and defocus by push–pull, filters the SVD pseudo-inverse, reconstructs
+known modal coefficients and demonstrates closed-loop convergence. The
+notebook executes from a clean kernel in CI.

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -7,11 +7,15 @@ the dependency set declared by the `tutorials` extra:
 python -m pip install -e '.[tutorials]'
 ```
 
-Notebooks 00–05 and 07–09 are self-contained and must execute independently from
+Notebooks 00–05, 07–09 and 11 are self-contained and must execute independently from
 a clean kernel. Notebook 07 demonstrates a complete ZELDA closed loop, from
 interaction-matrix calibration to the converged residual OPD. Continuous
 integration executes each notebook in a separate kernel, so variables and
 outputs from another tutorial cannot mask a missing definition.
+
+Notebook 11 validates the Shack–Hartmann chain from lenslet propagation and
+subpixel centroiding through push–pull calibration, SVD reconstruction and
+closed-loop correction of tip, tilt and defocus.
 
 Notebook 06 requires a directory of HARMONI residual FITS files. Set its path
 before launching Jupyter:

--- a/fiatlux/optics/shack_hartmann.py
+++ b/fiatlux/optics/shack_hartmann.py
@@ -421,6 +421,7 @@ class ShackHartmannLensletArray:
         valid_subapertures: torch.Tensor | None = None,
         pupil_transmission: torch.Tensor | None = None,
         minimum_illumination: float = 0.0,
+        spot_oversampling: int = 1,
     ) -> None:
         if not isinstance(grid, Grid):
             raise TypeError("grid must be a fiatlux Grid.")
@@ -429,6 +430,15 @@ class ShackHartmannLensletArray:
         self.focal_length = _positive_finite(focal_length, "focal_length")
         self.samples_x = self._integer_samples(self.pitch, grid.dx, "pitch / dx")
         self.samples_y = self._integer_samples(self.pitch, grid.dy, "pitch / dy")
+        if (
+            not isinstance(spot_oversampling, int)
+            or isinstance(spot_oversampling, bool)
+            or spot_oversampling < 1
+        ):
+            raise ValueError("spot_oversampling must be a positive integer.")
+        self.spot_oversampling = spot_oversampling
+        self.spot_samples_x = self.samples_x * spot_oversampling
+        self.spot_samples_y = self.samples_y * spot_oversampling
         maximum_x = grid.nx // self.samples_x
         maximum_y = grid.ny // self.samples_y
         self.n_lenslets_x = self._lenslet_count(n_lenslets_x, maximum_x, "x")
@@ -562,6 +572,17 @@ class ShackHartmannLensletArray:
             self.n_lenslets_x,
             self.samples_x,
         ).permute(0, 1, 3, 2, 4)
+        padding_x = self.spot_samples_x - self.samples_x
+        padding_y = self.spot_samples_y - self.samples_y
+        subapertures = functional.pad(
+            subapertures,
+            (
+                padding_x // 2,
+                padding_x - padding_x // 2,
+                padding_y // 2,
+                padding_y - padding_y // 2,
+            ),
+        )
         spectrum = torch.fft.fftshift(
             torch.fft.fft2(
                 torch.fft.ifftshift(subapertures, dim=(-2, -1)),
@@ -580,10 +601,10 @@ class ShackHartmannLensletArray:
             None, :, :, None, None
         ]
         pixel_scale_x = wavelengths * self.focal_length / (
-            self.samples_x * self.grid.dx
+            self.spot_samples_x * self.grid.dx
         )
         pixel_scale_y = wavelengths * self.focal_length / (
-            self.samples_y * self.grid.dy
+            self.spot_samples_y * self.grid.dy
         )
         return ShackHartmannImage(
             complex_amplitude=amplitude,

--- a/tests/test_shack_hartmann.py
+++ b/tests/test_shack_hartmann.py
@@ -46,6 +46,27 @@ def test_flat_wavefront_forms_regular_spots_and_conserves_flux():
     assert int((mosaic > 0).sum()) == 16
 
 
+def test_oversampled_spots_refine_sampling_and_conserve_flux():
+    grid = Grid(8, 8, 0.1, 0.1, dtype=torch.float64)
+    field = monochromatic_field(grid)
+    sensor = ShackHartmannLensletArray(
+        grid, pitch=0.4, focal_length=2.0, spot_oversampling=4
+    )
+
+    spots = sensor.propagate(field)
+    assert spots.complex_amplitude.shape == (1, 2, 2, 16, 16)
+    assert float(spots.pixel_scale_x[0]) == pytest.approx(
+        field.spectrum.wavelengths[0] * 2.0 / (16 * grid.dx)
+    )
+    input_flux = field.intensity().sum() * grid.dx * grid.dy
+    torch.testing.assert_close(spots.pixel_flux.sum(), input_flux)
+
+    with pytest.raises(ValueError, match="spot_oversampling"):
+        ShackHartmannLensletArray(
+            grid, pitch=0.4, focal_length=2.0, spot_oversampling=0
+        )
+
+
 def test_known_wavefront_tilt_moves_every_spot_with_correct_sign_and_scale():
     wavelength = 500e-9
     grid = Grid(16, 16, 0.1, 0.1, dtype=torch.float64)

--- a/tests/test_shack_hartmann_end_to_end.py
+++ b/tests/test_shack_hartmann_end_to_end.py
@@ -1,0 +1,129 @@
+import pytest
+import torch
+
+from fiatlux import (
+    ActuatorGrid,
+    DeformableMirror,
+    Grid,
+    InteractionMatrix,
+    PlaneWave,
+    ShackHartmannLensletArray,
+    ShackHartmannSlopeEstimator,
+    Spectrum,
+    ZernikeBasis,
+)
+from fiatlux.core.spectrum import Band
+
+
+def make_bench(*, dtype=torch.float64, device="cpu"):
+    grid = Grid(24, 24, 0.05, 0.05, dtype=dtype, device=device)
+    spectrum = Spectrum(
+        magnitude=0,
+        band=Band(650e-9, 0.0, 368.0),
+        samples=1,
+        dtype=dtype,
+        device=device,
+    )
+    field = PlaneWave(spectrum).generate_field(grid)
+    actuator_grid = ActuatorGrid(1, 1, 1.0)
+
+    def mirror():
+        return DeformableMirror(
+            grid,
+            actuator_grid,
+            grid,
+            ZernikeBasis(grid, n=3),
+            stroke=500e-9,
+        )
+
+    sensor = ShackHartmannLensletArray(
+        grid, pitch=0.2, focal_length=2.0, spot_oversampling=4
+    )
+    estimator = ShackHartmannSlopeEstimator(focal_length=2.0)
+    return field, mirror(), mirror(), sensor, estimator
+
+
+def slopes(field, mirror, sensor, estimator):
+    return estimator.measure(sensor.propagate(mirror.apply(field))).slope_vector
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_flat_and_low_order_zernike_responses_calibrate_with_expected_dtype(dtype):
+    field, _, correction, sensor, estimator = make_bench(dtype=dtype)
+    flat = slopes(field, correction, sensor, estimator)
+    torch.testing.assert_close(flat, torch.zeros_like(flat))
+
+    calibration = InteractionMatrix(
+        correction,
+        lambda: slopes(field, correction, sensor, estimator),
+        poke_amplitude=10e-9,
+    )
+    matrix = calibration.calibrate_push_pull(verbose=False)
+    control = calibration.compute_control_matrix(rcond=1e-5)
+
+    assert matrix.shape == (2 * 6 * 6, 3)
+    assert matrix.dtype == dtype
+    assert control.dtype == dtype
+    assert calibration.effective_rank == 3
+    assert torch.all(torch.linalg.vector_norm(matrix, dim=0) > 0)
+
+
+def test_interaction_matrix_recovers_tip_tilt_and_defocus_coefficients():
+    field, aberration, correction, sensor, estimator = make_bench()
+    calibration = InteractionMatrix(
+        correction,
+        lambda: slopes(field, correction, sensor, estimator),
+        poke_amplitude=10e-9,
+    )
+    calibration.calibrate_push_pull(verbose=False)
+    control = calibration.compute_control_matrix(rcond=1e-5)
+    injected = torch.tensor([12e-9, -8e-9, 6e-9], dtype=field.grid.dtype)
+    aberration.commands = injected
+
+    measurement = slopes(aberration.apply(field), correction, sensor, estimator)
+    reconstructed = control @ measurement
+
+    torch.testing.assert_close(reconstructed, injected, rtol=0.04, atol=0.2e-9)
+
+
+def test_closed_loop_reduces_low_order_residual():
+    field, aberration, correction, sensor, estimator = make_bench()
+    calibration = InteractionMatrix(
+        correction,
+        lambda: slopes(field, correction, sensor, estimator),
+        poke_amplitude=10e-9,
+    )
+    calibration.calibrate_push_pull(verbose=False)
+    control = calibration.compute_control_matrix(rcond=1e-5)
+    aberration.commands = torch.tensor(
+        [30e-9, -20e-9, 15e-9], dtype=field.grid.dtype
+    )
+
+    residuals = []
+    for _ in range(6):
+        measurement = slopes(
+            aberration.apply(field), correction, sensor, estimator
+        )
+        residuals.append(torch.linalg.vector_norm(measurement))
+        correction.commands = correction.commands - 0.7 * (control @ measurement)
+
+    assert residuals[-1] < 0.02 * residuals[0]
+    assert all(after < before for before, after in zip(residuals, residuals[1:]))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_end_to_end_calibration_runs_on_cuda():
+    field, _, correction, sensor, estimator = make_bench(
+        dtype=torch.float32, device="cuda"
+    )
+    calibration = InteractionMatrix(
+        correction,
+        lambda: slopes(field, correction, sensor, estimator),
+        poke_amplitude=10e-9,
+    )
+    matrix = calibration.calibrate_push_pull(verbose=False)
+    control = calibration.compute_control_matrix(rcond=1e-5)
+
+    assert matrix.device.type == "cuda"
+    assert control.device.type == "cuda"
+    assert calibration.effective_rank == 3

--- a/tutorials/11_shack_hartmann_end_to_end.ipynb
+++ b/tutorials/11_shack_hartmann_end_to_end.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shack–Hartmann: from pupil to closed loop\n",
+    "\n",
+    "This tutorial validates the complete deterministic chain: modal OPD, lenslet spots, calibrated slopes, interaction matrix, SVD reconstruction and closed-loop correction. OPD commands are in metres and slopes are in radians."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from fiatlux import (\n",
+    "    ActuatorGrid, DeformableMirror, Grid, InteractionMatrix, PlaneWave,\n",
+    "    ShackHartmannLensletArray, ShackHartmannSlopeEstimator, Spectrum,\n",
+    "    ZernikeBasis,\n",
+    ")\n",
+    "from fiatlux.core.spectrum import Band"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Optical bench\n",
+    "\n",
+    "A 24×24 pupil is divided into 6×6 subapertures. Two mirrors use the same tip, tilt and defocus basis: one injects the unknown OPD and one corrects it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtype = torch.float64\n",
+    "grid = Grid(24, 24, 0.05, 0.05, dtype=dtype)\n",
+    "spectrum = Spectrum(\n",
+    "    magnitude=0, band=Band(650e-9, 0.0, 368.0), samples=1, dtype=dtype\n",
+    ")\n",
+    "source_field = PlaneWave(spectrum).generate_field(grid)\n",
+    "actuators = ActuatorGrid(1, 1, 1.0)\n",
+    "\n",
+    "def make_mirror():\n",
+    "    return DeformableMirror(\n",
+    "        grid, actuators, grid, ZernikeBasis(grid, n=3), stroke=500e-9\n",
+    "    )\n",
+    "\n",
+    "aberration = make_mirror()\n",
+    "correction = make_mirror()\n",
+    "lenslets = ShackHartmannLensletArray(\n",
+    "    grid, pitch=0.20, focal_length=2.0, spot_oversampling=4\n",
+    ")\n",
+    "estimator = ShackHartmannSlopeEstimator(focal_length=2.0)\n",
+    "\n",
+    "def acquire(field, mirror=correction):\n",
+    "    return estimator.measure(lenslets.propagate(mirror.apply(field))).slope_vector\n",
+    "\n",
+    "flat_spots = lenslets.propagate(source_field)\n",
+    "flat_slopes = estimator.measure(flat_spots).slope_vector\n",
+    "assert torch.allclose(flat_slopes, torch.zeros_like(flat_slopes))\n",
+    "print(f\"Measurement vector: {flat_slopes.shape[0]} slopes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## 2. Flat and aberrated spot mosaics"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "injected = torch.tensor([30e-9, -20e-9, 15e-9], dtype=dtype)\n",
+    "aberration.commands = injected\n",
+    "aberrated_field = aberration.apply(source_field)\n",
+    "aberrated_spots = lenslets.propagate(aberrated_field)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(9, 4))\n",
+    "for ax, image, title in zip(\n",
+    "    axes,\n",
+    "    [flat_spots.mosaic(), aberrated_spots.mosaic()],\n",
+    "    [\"Flat wavefront\", \"Tip + tilt + defocus\"],\n",
+    "):\n",
+    "    view = image.detach().cpu()\n",
+    "    ax.imshow(view / view.max(), origin=\"lower\", cmap=\"magma\")\n",
+    "    ax.set_title(title)\n",
+    "    ax.set_xlabel(\"detector x pixel\")\n",
+    "    ax.set_ylabel(\"detector y pixel\")\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Push–pull calibration and reconstruction\n",
+    "\n",
+    "Each correction mode is poked by ±10 nm OPD. The control matrix is a filtered SVD pseudo-inverse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = InteractionMatrix(\n",
+    "    correction,\n",
+    "    lambda: acquire(source_field),\n",
+    "    poke_amplitude=10e-9,\n",
+    ")\n",
+    "interaction = calibration.calibrate_push_pull(verbose=False)\n",
+    "control = calibration.compute_control_matrix(rcond=1e-5)\n",
+    "print(\"Interaction matrix:\", tuple(interaction.shape))\n",
+    "print(\"Retained rank:\", calibration.effective_rank)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 3))\n",
+    "ax.semilogy(calibration.singular_values.detach().cpu(), \"o-\")\n",
+    "ax.set(xlabel=\"mode\", ylabel=\"singular value\", title=\"SH interaction matrix\")\n",
+    "ax.grid(True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "measured = acquire(aberrated_field)\n",
+    "reconstructed = control @ measured\n",
+    "print(\"Injected [nm]:     \", injected.mul(1e9).tolist())\n",
+    "print(\"Reconstructed [nm]:\", reconstructed.mul(1e9).tolist())\n",
+    "torch.testing.assert_close(reconstructed, injected, rtol=0.04, atol=0.2e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Closed loop\n",
+    "\n",
+    "The reconstructor sees only measured slopes. With an integrator gain of 0.7, the correction mirror converges toward the negative injected OPD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correction.flatten()\n",
+    "residuals = []\n",
+    "for iteration in range(7):\n",
+    "    residual_field = correction.apply(aberration.apply(source_field))\n",
+    "    measurement = estimator.measure(lenslets.propagate(residual_field))\n",
+    "    residuals.append(float(torch.linalg.vector_norm(measurement.slope_vector)))\n",
+    "    correction.commands = correction.commands - 0.7 * (control @ measurement.slope_vector)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 3))\n",
+    "ax.semilogy(residuals, \"o-\")\n",
+    "ax.set(xlabel=\"iteration\", ylabel=\"slope-vector norm [rad]\", title=\"Closed-loop convergence\")\n",
+    "ax.grid(True)\n",
+    "print(f\"Residual reduction: {residuals[0] / residuals[-1]:.1f}×\")\n",
+    "assert residuals[-1] < 0.02 * residuals[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example is intentionally noise-free so the analytical response and convergence can be checked quantitatively. A noisy exposure can be inserted between the lenslet array and estimator with ShackHartmannDetector, as described in the Shack–Hartmann documentation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -7,7 +7,13 @@ Progressive tutorial notebooks for the `fiatlux2.0` API.
 3. `02_polychromatic_psf.ipynb` — Multi-wavelength propagation
 4. `03_deformable_mirror.ipynb` — Zernike-controlled deformable mirror
 5. `04_zelda.ipynb` — ZELDA phase-mask wavefront sensor
-6. `05_interaction_matrix.ipynb` — Push-pull calibration and SVD control matrix
+6. `05_interaction_matrix_modal.ipynb` — Modal push-pull calibration and SVD
+7. `06_elt_pupil_from_harmoni.ipynb` — Analytical ELT/HARMONI pupil validation
+8. `07_closed_loop_ao.ipynb` — Closed-loop adaptive optics with ZELDA
+9. `08_near_field_propagation_contract.ipynb` — Near-field propagation contract
+10. `09_fresnel_physical_validation.ipynb` — Physical Fresnel validation
+11. `10_fatmoss_temporal_turbulence.ipynb` — FATMOSS temporal turbulence
+12. `11_shack_hartmann_end_to_end.ipynb` — Shack-Hartmann calibrated closed loop
 
 These notebooks are written against the current `fiatlux2.0` API and may expose
 the core issues identified during code review, particularly monochromatic


### PR DESCRIPTION
## Summary

- add optional focal-spot oversampling by centred pupil-plane zero padding, with physical pixel scales and Parseval flux normalization preserved
- validate flat-wavefront response and non-zero tip, tilt and defocus sensitivities
- calibrate the real Shack-Hartmann slope vector against a three-mode Zernike DM using push-pull measurements
- reconstruct known modal OPD coefficients with a filtered SVD control matrix
- demonstrate monotonic closed-loop reduction of a tip/tilt/defocus residual
- cover float32, float64 and CUDA when available
- add a clean-kernel tutorial showing spot mosaics, singular values, reconstructed nanometres and convergence
- refresh the maintained tutorial index and Shack-Hartmann documentation

## Why focal oversampling is included

At native 4x4 lenslet sampling, a perfectly centred diffraction spot does not provide a sufficiently linear subpixel centre-of-gravity response around zero. `spot_oversampling` performs centred zero padding before the focal FFT. The default remains one for compatibility; the calibrated example uses four. This improves detector-plane sampling without changing the pupil sampling or total photon flux.

## Validation

Static Python compilation, notebook JSON validation, extracted-cell compilation, clean output/counter checks and whitespace checks pass locally. The GitHub test and clean-kernel tutorial jobs are authoritative for the numerical PyTorch execution.

Closes #81